### PR TITLE
Fix bug if no trigger paths specified on command-line

### DIFF
--- a/server/src/commandLine.mjs
+++ b/server/src/commandLine.mjs
@@ -60,9 +60,11 @@ console.log(`Enabled Firebolt SDKs: ${enabledSdkNames.join(', ')}`);
 
 // --- Trigger paths specified via --triggers/-t
 
-const enabledTriggerPaths = parsed.triggers;
+const enabledTriggerPaths = parsed.triggers || [];
 
-console.log(`Triggers will be read from these paths: ${enabledTriggerPaths.join(', ')}`);
+if ( enabledTriggerPaths.length > 0 ) {
+  console.log(`Triggers will be read from these paths: ${enabledTriggerPaths.join(', ')}`);
+}
 
 // --- Exports ---
 


### PR DESCRIPTION
Bug: Running "npm run dev" (vs. "npm run dev -- --triggers ./src/triggers") crashes because enabledTriggerPaths is null/undefined and not []. Fixed by ensuring this variable is always an array.

Also, don't show log message if no trigger directories have been specified.