### PR TITLE
Fix parameter validation logic

### DIFF
--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -100,10 +100,12 @@ function validateMethodCall(methodName, params) {
         oSchema = getSchema(schemaName);
       }
 
-      const validate = ajv.compile(oSchema);
-      const valid = validate(params[paramName]);
-      if ( !valid ) {
-        errors.push(validate.errors);
+      if ( oSchema.required || params[paramName] ) {
+        const validate = ajv.compile(oSchema);
+        const valid = validate(params[paramName]);
+        if ( !valid ) {
+          errors.push(validate.errors);
+        }
       }
     }
 


### PR DESCRIPTION
Previously, validation was failing for optional parameters. This fix fixes that.
Example, SecondScreen.device(null) or SecondScreen.device() will now pass parameter validation.