### PR TITLE
Fix bug with required params + always use dereferenced metadata

### DIFF
--- a/server/src/routes/api/meta.mjs
+++ b/server/src/routes/api/meta.mjs
@@ -28,9 +28,9 @@ import * as fireboltOpenRpc from '../../fireboltOpenRpc.mjs';
 function getMeta(req, res) {
   let meta;
   if ( req.query.dereference !== 'true' ) {
-    meta = fireboltOpenRpc.getMeta();
+    meta = fireboltOpenRpc.getRawMeta();
   } else {
-    meta = fireboltOpenRpc.getDereferencedMeta();
+    meta = fireboltOpenRpc.getMeta();
   }
   res.status(200).send({
     status: 'SUCCESS',


### PR DESCRIPTION
Hopefully fixes the validation bug for good.
- Looks for the required property in the right data structure (oParam)
- Always uses dereferenced metadata to ensure any/all $refs are resolved before validation
- Ensures the /api/v1/meta[?dereference=true] endpoint still works
Tested for all remaining parameter failures reported by QA team