### PR TITLE
Support absolute path open rpc files

### DIFF
--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -22,6 +22,7 @@
 'use strict';
 
 import { readFile } from 'fs/promises';
+import * as path from 'path';
 import * as fs from 'fs';
 import * as https from 'https';
 
@@ -240,7 +241,14 @@ async function readSdkJsonFileIfEnabled(sdkName) {
       const oSdk = config.dotConfig.supportedSdks.find((oSdk) => { return ( oSdk.name === sdkName ); });
       if ( oSdk.fileName ) {
         const openRpcFileName = oSdk.fileName;
-        fileUrl = new URL(`./${openRpcFileName}`, import.meta.url);
+        if ( path.isAbsolute(openRpcFileName) || openRpcFileName.startsWith('~') ) {
+          // Absolute file path given -- read from that file path exactly as-is
+          fileUrl = new URL(openRpcFileName, import.meta.url);
+        } else {
+          // Relative file path given -- read from file with given name from current
+          // directory (build/), assuming file was copied there/here via a build step
+          fileUrl = new URL(`./${openRpcFileName}`, import.meta.url);
+        }
         rawMeta[sdkName] = JSON.parse(
           await readFile(fileUrl)
         );


### PR DESCRIPTION
Support absolute path values for "fileName" in .mf.config.json files. This will allow a user to download an open rpc file and then provide a full absolute path to wherever she puts the file.