### PR TITLE
Scratch support plus bug fixes

### DIFF
--- a/cli/examples/closed-captions-settings-reset.json
+++ b/cli/examples/closed-captions-settings-reset.json
@@ -1,0 +1,19 @@
+{
+  "scratch": {
+    "closedCaptionsSettings": {
+      "enabled": true,
+      "styles": {
+        "fontFamily": "Monospace sans-serif",
+        "fontSize": 1,
+        "fontColor": "#ffffff",
+        "fontEdge": "none",
+        "fontEdgeColor": "#7F7F7F",
+        "fontOpacity": 100,
+        "backgroundColor": "#000000",
+        "backgroundOpacity": 100,
+        "textAlign": "center",
+        "textAlignVertical": "middle"
+      }
+    }
+  }
+}

--- a/cli/examples/closed-captions-settings.yaml
+++ b/cli/examples/closed-captions-settings.yaml
@@ -1,0 +1,27 @@
+---
+methods:
+  closedcaptions.enabled:
+    response: |
+      function f(ctx, params) {
+        const ccs = ctx.get('closedCaptionsSettings');
+        if ( params && params.hasOwnProperty('value') ) {
+          // Setter called:
+          // Cause an accessibility.onClosedCaptionsSettingsChanged event
+          // (done via post-method trigger on closedcaptions.enabled method)
+          // Save for when accessibility.closedCaptionsSettings is called
+          ccs.enabled = params.value;
+          ctx.set('closedCaptionsSettings', ccs);
+          return true;
+        } else {
+          // Getter called:
+          // Return what we last saved when this func was called as a setter
+          return ccs.enabled;
+        }
+      }
+  accessibility.closedCaptionsSettings:
+    response: |
+      function f(ctx, params) {
+        // Getter called... Return our stashed value, per last setter call
+        const ccs = ctx.get('closedCaptionsSettings');
+        return ccs;
+      }

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -20,6 +20,7 @@
 
 'use strict';
 
+import * as stateManagement from './stateManagement.mjs';
 import { eventTriggers } from './triggers.mjs';
 import { logger } from './logger.mjs';
 
@@ -94,7 +95,7 @@ function sendEventListenerAck(ws, oMsg) {
 }
 
 // sendEvent to handle post API event calls, including pre- and post- event trigger processing
-function sendEvent(ws, method, result, msg, fSuccess, fErr, fFatalErr) {
+function sendEvent(ws, userId, method, result, msg, fSuccess, fErr, fFatalErr) {
   try {
     if ( !isRegisteredEventListener(method) ) {
       logger.info(`${method} event not registered`);
@@ -108,6 +109,8 @@ function sendEvent(ws, method, result, msg, fSuccess, fErr, fFatalErr) {
               logger: logger,
               setTimeout: setTimeout,
               setInterval: setInterval,
+              set: function ss(key, val) { return stateManagement.setScratch(userId, key, val) },
+              get: function gs(key) { return stateManagement.getScratch(userId, key); },
               sendEvent: function(method, result, msg) {
                 function fSuccess() {
                   logger.info(`${msg}: Sent event ${method} with result ${JSON.stringify(result)}`)
@@ -118,7 +121,7 @@ function sendEvent(ws, method, result, msg, fSuccess, fErr, fFatalErr) {
                 function fFatalErr() {
                   logger.info(`Internal error`)
                 }
-                sendEvent(ws, method, result, msg, fSuccess, fErr, fFatalErr);
+                sendEvent(ws, userId, method, result, msg, fSuccess, fErr, fFatalErr);
               }
             };
             logger.debug(`Calling pre trigger for event ${method}`);
@@ -141,6 +144,8 @@ function sendEvent(ws, method, result, msg, fSuccess, fErr, fFatalErr) {
               logger: logger,
               setTimeout: setTimeout,
               setInterval: setInterval,
+              set: function ss(key, val) { return stateManagement.setScratch(userId, key, val) },
+              get: function gs(key) { return stateManagement.getScratch(userId, key); },
               sendEvent: function(method, result, msg) {
                 function fSuccess() {
                   logger.info(`${msg}: Sent event ${method} with result ${JSON.stringify(result)}`)

--- a/server/src/routes/api/event.mjs
+++ b/server/src/routes/api/event.mjs
@@ -20,6 +20,7 @@
 
 'use strict';
 
+import { getUserIdFromReq } from '../../util.mjs';
 import * as events from '../../events.mjs';
 
 // --- Route Handlers ---
@@ -28,6 +29,7 @@ import * as events from '../../events.mjs';
 // Expected body: { method: 'device.onDeviceNameChanged' result: ... }
 function sendEvent(req, res) {
   const { ws } = res.locals; // Like magic!
+  const userId = getUserIdFromReq(req);
   const { method, result } = req.body;
 
   function fSuccess() {
@@ -53,7 +55,7 @@ function sendEvent(req, res) {
     });
   }
 
-  events.sendEvent(ws, method, result, '', fSuccess, fErr, fFatalErr);
+  events.sendEvent(ws, userId, method, result, '', fSuccess, fErr, fFatalErr);
 }
 
 // --- Exports ---

--- a/server/src/triggers/methodTriggers/closedcaptions.enabled/post.mjs
+++ b/server/src/triggers/methodTriggers/closedcaptions.enabled/post.mjs
@@ -1,0 +1,13 @@
+function post(ctx, params) {
+  if ( params && params.hasOwnProperty('value') ) {
+    // Called as a settr
+    const msg = 'Post trigger for closedcaptions.enabled sent accessibility.onClosedCaptionsSettingsChanged event';
+    const ccs = ctx.get('closedCaptionsSettings');
+    // Ensure that the change event contains our stashed value, so it matches what the app gets from a getter call
+    ctx.sendEvent('accessibility.onClosedCaptionsSettingsChanged', ccs, msg);
+    return ccs.enabled;
+  } else {
+    // Called as a gettr
+    return undefined; // "Use whatever value you were going to use; I have no override/opinion"
+  }
+}


### PR DESCRIPTION
- Added ctx.set() and ctx.get() to ctx passed to pre- and post- triggers for both methods and events
- To do this, needed to export stateManagement.mjs::setScratch and ::getScratch
- These methods take userId, so needed to flow userId all the refactored methods in stateManagement.mjs
- Also needed to pass methodName to these refactored methods because it is used in error messages
- Added two example files, closed-captions-settings-reset.json and closed-captions-settings.yaml.
- Added one new example trigger in triggers/methodTriggers/closedcaptions.enabled/post.mjs

To test,
- Start Mock Firebolt using: npm run dev -- --manage --triggers ./src/triggers
    - Note that this enables the manage sdk (so you can use ClosedCaptions.enabled(false|true)) and loads the above trigger (among others)
- Do: node cli.mjs --upload ../examples/closed-captions-settings-reset.json
    - This sets the scratch k-v 'database' value for 'closedCaptionsSettings' to a default/starter value
- Do: node cli.mjs --upload ../examples/closed-captions-settings.yaml      
    - This provides the dynamic mock override 'values' (functions) 
- Run the test app

The app code I used to test looks like:

>    let value, onOff;
> 
>     console.log('--------------------------closed1');
> 
>     value = false;
>     onOff = ( value ? 'on' : 'off' );
> 
>     console.log(`Calling Manage SDK's ClosedCaptions.enabled(${value}) to turn ${onOff} closed captions...`);
>     data = await ClosedCaptions.enabled(value);
>     console.log(`Used Manage SDK's ClosedCaptions.enabled(${value}) to turn ${onOff} closed captions`);
> 
>     console.log(`Calling SDK's ClosedCaptions.enabled()...`);
>     data = await ClosedCaptions.enabled();
>     console.log(`Manage SDK's ClosedCaptions.enabled() returned: ${data}`);
> 
>     console.log(`Calling Core SDK's Accessibility.closedCaptionsSettings()...`);
>     data = await Accessibility.closedCaptionsSettings();
>     console.log(`Core SDK's Accessibility.closedCaptionsSettings() returned: ${JSON.stringify(data)}`);
> 
>     console.log('--------------------------closed2');
> 
>     value = true;
>     onOff = ( value ? 'on' : 'off' );
> 
>     console.log(`Calling Manage SDK's ClosedCaptions.enabled(${value}) to turn ${onOff} closed captions`);
>     data = await ClosedCaptions.enabled(value);
>     console.log(`Used Manage SDK's ClosedCaptions.enabled(${value}) to turn ${onOff} closed captions`);
> 
>     console.log(`Calling SDK's ClosedCaptions.enabled()...`);
>     data = await ClosedCaptions.enabled();
>     console.log(`Manage SDK's ClosedCaptions.enabled() returned: ${data}`);
> 
>     console.log(`Calling Core SDK's Accessibility.closedCaptionsSettings()...`);
>     data = await Accessibility.closedCaptionsSettings();
>     console.log(`Core SDK's Accessibility.closedCaptionsSettings() returned: ${JSON.stringify(data)}`);
> 
>     console.log('--------------------------closed3');
