### PR TITLE
bug fix for invalid event listeners

### DIFF
--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -47,19 +47,6 @@ async function handleMessage(message, userId, ws) {
     return;
   }
 
-  // Handle JSON-RPC messages that are event listener enable requests
-  if ( events.isEventListenerOnMessage(oMsg) ) {
-    events.sendEventListenerAck(ws, oMsg);
-    events.registerEventListener(oMsg);
-    return;
-  }
-  
-  // Handle JSON-RPC messages that are event listener disable requests
-  if ( events.isEventListenerOffMessage(oMsg) ) {
-    events.deregisterEventListener(oMsg);
-    return;
-  }
-
   // Handle JSON-RPC message that is somehow for an unknown method
   if ( ! fireboltOpenRpc.isMethodKnown(oMsg.method) ) {
     // Somehow, we got a socket message representing a Firebolt method call for a method name we don't recognize!
@@ -76,6 +63,19 @@ async function handleMessage(message, userId, ws) {
     // No delay
     ws.send(responseMessage);
     logger.info(`Sent "method not found" message: ${responseMessage}`);
+    return;
+  }
+
+  // Handle JSON-RPC messages that are event listener enable requests
+  if ( events.isEventListenerOnMessage(oMsg) ) {
+    events.sendEventListenerAck(ws, oMsg);
+    events.registerEventListener(oMsg);
+    return;
+  }
+
+  // Handle JSON-RPC messages that are event listener disable requests
+  if ( events.isEventListenerOffMessage(oMsg) ) {
+    events.deregisterEventListener(oMsg);
     return;
   }
 


### PR DESCRIPTION
The issue was in MessageHandler.mjs -> HandleMessage Function. For any event, the check was whether is contains ".on" . Mfos was registering the invalid event (as it contains .on ) and the HandleMessage function ends there .Function was not executing the actual validation for any method/event because this validation. So, I changed the position of code validating the method/event.