### PR TITLE
Add REST endpoint to add user

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -434,3 +434,22 @@ curl --location --request POST 'http://localhost:3333/api/v1/sequence' \
     "status": "OK"
 }
 ```
+
+
+
+## Create a user (generates a UUID v4 and registers a user with this User ID)
+
+### Example cURL Command:
+
+```
+curl --location --request POST 'http://localhost:3333/api/v1/user'
+```
+
+### 200 Response:
+
+```
+{
+    "status": "OK",
+    "userId": "<uuid>"
+}
+```

--- a/server/src/configureAPI.mjs
+++ b/server/src/configureAPI.mjs
@@ -23,6 +23,7 @@
 import * as healthApi from './routes/api/health.mjs';
 import * as metaApi from './routes/api/meta.mjs';
 import * as stateApi from './routes/api/state.mjs';
+import * as userApi from './routes/api/user.mjs';
 import * as eventApi from './routes/api/event.mjs';
 import * as sessionApi from './routes/api/session.mjs';
 import * as sequenceApi from './routes/api/sequence.mjs';
@@ -62,6 +63,10 @@ function configureAPI(app) {
 	// Revert to the way things were when server started up
     app.post('/api/v1/state/revert',                    stateApi.revertState);
 
+    // ======================= State-Related API Routes =======================
+
+    app.post('/api/v1/user',                            userApi.addUser);
+
 	// ======================= Event-Related API Routes =======================
 
     // Send an event
@@ -70,18 +75,18 @@ function configureAPI(app) {
     // ======================= Session-Related API Routes =======================
 
     // Toggle session state
-    app.post('/api/v1/session',                        sessionApi.toggleSession);
+    app.post('/api/v1/session',                         sessionApi.toggleSession);
 
     // Start a session
-    app.post('/api/v1/session/start',                  sessionApi.startSession);
+    app.post('/api/v1/session/start',                   sessionApi.startSession);
 
     // End a session
-    app.post('/api/v1/session/stop',                   sessionApi.stopSession);
+    app.post('/api/v1/session/stop',                    sessionApi.stopSession);
 
     // ======================= Sequence-Related API Routes =======================
 
     // Send an event sequence
-    app.post('/api/v1/sequence',                       sequenceApi.sendSequence);
+    app.post('/api/v1/sequence',                        sequenceApi.sendSequence);
 }
 
 export { configureAPI };

--- a/server/src/routes/api/user.mjs
+++ b/server/src/routes/api/user.mjs
@@ -1,0 +1,51 @@
+/*
+* Copyright 2021 Comcast Cable Communications Management, LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+// HTTP-based API routes: User-Related
+
+'use strict';
+
+import { v4 as uuidv4 } from 'uuid';
+import * as userManagement from '../../userManagement.mjs';
+import * as stateManagement from '../../stateManagement.mjs';
+
+
+// --- Route Handlers ---
+
+// POST /api/v1/user
+// Expected body: N/A
+function addUser(req, res) {
+  // Generate a unique userId for this user (no vanity userIds, at least for now)
+  const userId = uuidv4();
+
+  // Make sure we have a web socket server for this user
+  userManagement.addUser(userId);
+  // Make sure we have starter (empty) state for this user
+  stateManagement.addUser(userId);
+
+  res.status(200).send({
+    status: 'SUCCESS',
+    userId: userId
+  });
+}
+
+// --- Exports ---
+
+export {
+  addUser
+};


### PR DESCRIPTION
If you want to create a user dynamically, you can now POST to /api/v1/user. In the response object, there will be a userId key. The value of that key is the new user id, which is now registered as a user in Mock Firebolt. As always, realize that Mock Firebolt doesn't currently persist anything anywhere, so if/when the server is stopped or crashes, this user id will no longer exist.