### PR TITLE
support concurrent proxy connection

### DIFF
--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -42,11 +42,7 @@ function fFatalErr() {
 }
 
 // Process given message and send any ack/reply to given web socket connection
-async function handleMessage(imessage, iuserId, iws) {
-
-  const message = imessage
-  const userId = iuserId
-  const ws = iws
+async function handleMessage(message, userId, ws) {
   let response, newResponse;
 
   logger.debug(`Received message: ${message}`);

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -42,7 +42,11 @@ function fFatalErr() {
 }
 
 // Process given message and send any ack/reply to given web socket connection
-async function handleMessage(message, userId, ws) {
+async function handleMessage(imessage, iuserId, iws) {
+
+  const message = imessage
+  const userId = iuserId
+  const ws = iws
   let response, newResponse;
 
   logger.debug(`Received message: ${message}`);
@@ -161,12 +165,7 @@ async function handleMessage(message, userId, ws) {
     //bypass JSON-RPC calls and hit proxy server endpoint
     //init websocket connection for proxy request to be sent and use receiver client to send events back to caller.
     try {
-      if(await proxyManagement.initialize(proxyManagement.actOnResponseObject, ws)) {
-        proxyManagement.sendRequest(JSON.stringify(oMsg))
-        response = await proxyManagement.getResponseMessageFromProxy(oMsg.id)
-      } else {
-        console.log("Websocket connection not initialized")
-      }
+      response = await proxyManagement.initializeAndSendRequest(ws, JSON.stringify(oMsg))
     } catch (err) {
       logger.error(`ERROR: Unable to establish proxy connection due to ${err}`)
       process.exit(1)

--- a/server/src/proxyManagement.mjs
+++ b/server/src/proxyManagement.mjs
@@ -69,7 +69,7 @@ function closeStaleConnections() {
   let timeout = 1000
   let counter = 0
   let interval = 100
-  var timer = setInterval(function() {
+  let timer = setInterval(function() {
     //if all connection closed, clear interval
     if(wsConn.length == 0) {
       closeConnectionTrigger = false

--- a/server/test/suite/proxyManagement.test.mjs
+++ b/server/test/suite/proxyManagement.test.mjs
@@ -4,6 +4,7 @@ import { jest } from "@jest/globals";
 import * as proxyManagement from "../../src/proxyManagement.mjs";
 
 jest.setTimeout(80 * 1000)
+
 describe('sequentially run tests', () => {
 
     beforeAll(() => {
@@ -29,31 +30,19 @@ describe('sequentially run tests', () => {
         expect(token.error).toBe("Unable to get token from connection param or not present in env");
     });
 
-    test(`proxyManagement.actOnResponseObject works properly with mock`, async () => {
-        const data = {"jsonrpc":"2.0","id":1,"result":{"type":"device","value":"<XACT Token>"}}
-        proxyManagement.actOnResponseObject(JSON.stringify(data), null)
-        const res = await proxyManagement.getResponseMessageFromProxy(data.id)
-        expect(res).toBe(JSON.stringify(data))
-    })
-
     test(`Handle error when url not passed`, async () => {
         delete process.env.proxyServerIP
-        proxyManagement.initialize(null, null).catch(function (err) {
+        proxyManagement.initializeAndSendRequest(null, null).catch(function (err) {
             // Only executed if rejects the promise
             expect(err.toString()).toContain('Error: ERROR: Proxy Url not found in env')
         });
         
     })
 
-    test(`proxyManagement.sendRequest works properly`, async () => {
-        proxyManagement.sendRequest(null)
-    })
-
     test(`proxyManagement.initialize works properly`, async () => {
         try {
             process.env.proxyServerIP = "localhost.test"
-            const response = await proxyManagement.initialize(proxyManagement.actOnResponseObject, null)
-            console.log("response: ", response)
+            await proxyManagement.initializeAndSendRequest(null, null)
         } catch (e) {
             expect(e.errno).toBe(-3008);
             expect(e.code).toBe("ENOTFOUND");


### PR DESCRIPTION
initializeAndSendRequest method will open new websocket for each request.
Once response received from proxy, it will start closing all stale connections.
(ex: if 10 connections open for 10 request, closeStaleConnection method will close the WS connection after interval of 10s one after other. )
This way, it will execute post trigger and stale connections won't be open all the time. 