### PR TITLE
SYSTEST-9338 - Send events to the WS object that subscribed to it

### DIFF
--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -58,7 +58,11 @@ function registerEventListener(userId, oMsg, ws) {
     eventListenerMap[userId][oMsg.method] = { id: oMsg.id, wsArr: [] };
   }
 
-  eventListenerMap[userId][oMsg.method].wsArr.push(ws);
+  // Check if ws is already in the wsArr before pushing
+  if (!eventListenerMap[userId][oMsg.method].wsArr.includes(ws)) {
+    eventListenerMap[userId][oMsg.method].wsArr.push(ws);
+  }
+
   logger.debug(`Registered event listener mapping: ${userId}:${oMsg.method}:${oMsg.id}`);
 }
 

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -83,14 +83,14 @@ async function handleMessage(message, userId, ws) {
 
   if ( events.isEventListenerOnMessage(oMsg) ) {
     events.sendEventListenerAck(userId, ws, oMsg);
-    events.registerEventListener(userId, oMsg);
+    events.registerEventListener(userId, oMsg, ws);
     return;
   }
 
   // Handle JSON-RPC messages that are event listener disable requests
 
   if ( events.isEventListenerOffMessage(oMsg) ) {
-    events.deregisterEventListener(userId, oMsg);
+    events.deregisterEventListener(userId, oMsg, ws);
     return;
   }
 

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -307,12 +307,15 @@ test(`events.sendBroadcastEvent works properly`, () => {
 
 test(`events.emitResponse works properly`, () => {
   const spy = jest.spyOn(logger, "info");
-  events.testExports.emitResponse(
-    { send: () => {} },
-    {},
-    "test_msg",
-    "12345",
-    "core"
-  );
+  const listenerObject = {
+    method: "core",
+    id: 12,
+  };
+  const dummyWebSocket = { send: () => {} };
+
+  // Register the event listener first to simulate a real-world scenario
+  events.registerEventListener("12345", listenerObject, dummyWebSocket);
+
+  events.testExports.emitResponse({}, "test_msg", "12345", "core");
   expect(spy).toHaveBeenCalled();
 });

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -31,7 +31,8 @@ test(`events.registerEventListener works properly`, () => {
     method: "",
     id: 12,
   };
-  events.registerEventListener("12345", dummyObject);
+  const dummyWebSocket = { send: () => {} };
+  events.registerEventListener("12345", dummyObject, dummyWebSocket);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -92,7 +93,8 @@ test(`events.getRegisteredEventListener works properly if path`, () => {
 test(`events.deregisterEventListener works properly`, () => {
   const spy = jest.spyOn(logger, "debug");
   const oMsgdummy = { method: "lifecycle.onInactive", id: 12 };
-  events.deregisterEventListener(oMsgdummy);
+  const dummyWebSocket = { send: () => {} };
+  events.deregisterEventListener("12345", oMsgdummy.method, dummyWebSocket);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -177,7 +179,8 @@ test(`events.isEventListenerOffMessage works properly`, () => {
 test(`events.sendEventListenerAck works properly`, () => {
   const spy = jest.spyOn(logger, "debug");
   const oMsgdummy = { method: "lifecycle.onInactive", id: 12 };
-  events.sendEventListenerAck('12345', { send: () => {} }, oMsgdummy);
+  const dummyWebSocket = { send: () => {} };
+  events.sendEventListenerAck("12345", dummyWebSocket, oMsgdummy);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -205,9 +208,11 @@ test(`events.sendEvent works properly`, () => {
       call: () => {},
     },
   };
-  events.registerEventListener("12345", dummyObject);
+  const dummyWebSocket = { send: () => {} };
+
+  events.registerEventListener("12345", dummyObject, dummyWebSocket);
   events.sendEvent(
-    { send: () => {} },
+    dummyWebSocket,
     "12345",
     methodName,
     result,
@@ -286,8 +291,9 @@ test(`events.isAnyRegisteredInGroup works properly with if path`, () => {
 });
 
 test(`events.sendBroadcastEvent works properly`, () => {
+  const dummyWebSocket = { send: () => {} };
   const result = events.testExports.sendBroadcastEvent(
-    { send: () => {} },
+    dummyWebSocket,
     "12345",
     "core",
     {},


### PR DESCRIPTION
**Background**
Mock Firebolt now supports multiple connections per user by utilizing an array/map of WS connections per userId.

This presents a problem for situations in which MF is tasked with triggering an event for a user. If a user is connected to MF with multiple connections, there is currently no way for MF to know which connection to send the requested event to.

In order to properly inject events, we must know which connection began listening to the requested event.

**Implementation**
MF already keeps track of which users are listening to which events. This is in order to support "sendEvent()" and "sendBroadcastEvent()" functionalities in YAML overrides as well as sending events manually using the --event CLI and its associated API. This same functionality can be extended to include which connection is listening to an event.

From there, the event functionality can be enhanced to send events to only the connections that are listening for it.

**Changes Made**
* Pass WS object to _registerEventListener_ and _deregisterEventListener_ functions inside of _messageHandler.mjs_.
* Modify _registerEventListener_, _deregisterEventListener_, & _emitResponse_ functions inside of _events.mjs_.
* _registerEventHandler_ now takes in a ws object and it is added in the eventListenerMap. 
* When it is time to call _emitResponse_, the WS object is retrieved from the eventListenerMap and used to send the response.