### PR TITLE
SYSTEST-9348-Use the word "group" as a shortcut for the user's group in ctx functions

### DIFF
--- a/functional/tests/core-manage-jsonrpc.test.mjs
+++ b/functional/tests/core-manage-jsonrpc.test.mjs
@@ -40,7 +40,7 @@ afterAll(async () => {
 test(`Validate OPENRPC Response for manage SDK`, async () => {
   const response = await utilities.fireboltCommand(
     JSON.stringify({
-      method: "accessory.list",
+      method: "Accessory.list",
       params: {},
       id: 0,
     })

--- a/server/src/stateManagement.mjs
+++ b/server/src/stateManagement.mjs
@@ -705,19 +705,19 @@ and if userid invoking the YAML contains group, the group of the userId will be 
 else,  the full userid is used along with warning
 */
 function setScopeForGroupKeyword(userId, scope) {
-  let parseUserId = parseUser(userId)
-  if (parseUserId.group == undefined || parseUserId.group == null) {
+  let parsedUserId = parseUser(userId)
+  if (!parsedUserId.group) {
     logger.warning("WARNING: userId does not contain a group. Using full userId for manipulating scratch")
     scope = userId
   } else {
-    scope = '~' + parseUserId.group
+    scope = '~' + parsedUserId.group
   }
   return scope
 }
 
 // set scratch space of scope with the provided key-value
 function setScratch(userId, key, val, scope) {
-  if (scope == 'group') {
+  if (scope === 'group') {
     scope = setScopeForGroupKeyword(userId, scope)
   }
   updateState(userId, {
@@ -729,7 +729,7 @@ function setScratch(userId, key, val, scope) {
 
 // get key from scratch space of provided scope
 function getScratch(userId, key, scope) {
-  if (scope == 'group') {
+  if (scope === 'group') {
     userId = setScopeForGroupKeyword(userId, scope)
   }
   const userState = getState(userId);
@@ -742,7 +742,7 @@ function getScratch(userId, key, scope) {
 // delete key from scratch space of provided scope
 function deleteScratch(userId, key, scope=""){
   if (scope !== "") {
-    if (scope == 'group') {
+    if (scope === 'group') {
       scope = setScopeForGroupKeyword(userId, scope)
     }
     if (scope in state && key in state[scope].scratch) {

--- a/server/src/stateManagement.mjs
+++ b/server/src/stateManagement.mjs
@@ -707,7 +707,7 @@ else,  the full userid is used along with warning
 function setScopeForGroupKeyword(userId, scope) {
   let parseUserId = parseUser(userId)
   if (parseUserId.group == undefined || parseUserId.group == null) {
-    logger.warning("UserId does not contain a group. Using full userid for manipulating scratch")
+    logger.warning("WARNING: userId does not contain a group. Using full userId for manipulating scratch")
     scope = userId
   } else {
     scope = '~' + parseUserId.group

--- a/server/src/stateManagement.mjs
+++ b/server/src/stateManagement.mjs
@@ -705,19 +705,19 @@ and if userid invoking the YAML contains group, the group of the userId will be 
 else,  the full userid is used along with warning
 */
 function setScopeForGroupKeyword(userId, scope) {
-  let parsedUserId = parseUser(userId)
-  if (!parsedUserId.group) {
+  let parseUserId = parseUser(userId)
+  if (parseUserId.group == undefined || parseUserId.group == null) {
     logger.warning("WARNING: userId does not contain a group. Using full userId for manipulating scratch")
     scope = userId
   } else {
-    scope = '~' + parsedUserId.group
+    scope = '~' + parseUserId.group
   }
   return scope
 }
 
 // set scratch space of scope with the provided key-value
 function setScratch(userId, key, val, scope) {
-  if (scope === 'group') {
+  if (scope == 'group') {
     scope = setScopeForGroupKeyword(userId, scope)
   }
   updateState(userId, {
@@ -729,7 +729,7 @@ function setScratch(userId, key, val, scope) {
 
 // get key from scratch space of provided scope
 function getScratch(userId, key, scope) {
-  if (scope === 'group') {
+  if (scope == 'group') {
     userId = setScopeForGroupKeyword(userId, scope)
   }
   const userState = getState(userId);
@@ -742,7 +742,7 @@ function getScratch(userId, key, scope) {
 // delete key from scratch space of provided scope
 function deleteScratch(userId, key, scope=""){
   if (scope !== "") {
-    if (scope === 'group') {
+    if (scope == 'group') {
       scope = setScopeForGroupKeyword(userId, scope)
     }
     if (scope in state && key in state[scope].scratch) {

--- a/server/src/stateManagement.mjs
+++ b/server/src/stateManagement.mjs
@@ -700,7 +700,26 @@ function setMethodError(userId, methodName, code, message) {
   });
 }
 
+/* if "group" keyword is passed for scope inside ctx functions, 
+and if userid invoking the YAML contains group, the group of the userId will be used as the "scope" for that call
+else,  the full userid is used along with warning
+*/
+function setScopeForGroupKeyword(userId, scope) {
+  let parseUserId = parseUser(userId)
+  if (parseUserId.group == undefined || parseUserId.group == null) {
+    logger.warning("UserId does not contain a group. Using full userid for manipulating scratch")
+    scope = userId
+  } else {
+    scope = '~' + parseUserId.group
+  }
+  return scope
+}
+
+// set scratch space of scope with the provided key-value
 function setScratch(userId, key, val, scope) {
+  if (scope == 'group') {
+    scope = setScopeForGroupKeyword(userId, scope)
+  }
   updateState(userId, {
     scratch: {
       [key]: val
@@ -708,9 +727,12 @@ function setScratch(userId, key, val, scope) {
   }, scope);
 }
 
-function getScratch(userId, key) {
+// get key from scratch space of provided scope
+function getScratch(userId, key, scope) {
+  if (scope == 'group') {
+    userId = setScopeForGroupKeyword(userId, scope)
+  }
   const userState = getState(userId);
-
   if ( key in userState.scratch ) {
     return userState.scratch[key];
   }
@@ -719,8 +741,11 @@ function getScratch(userId, key) {
 
 // delete key from scratch space of provided scope
 function deleteScratch(userId, key, scope=""){
-  if ( scope !== "" ){
-    if ( scope in state && key in state[scope].scratch ){
+  if (scope !== "") {
+    if (scope == 'group') {
+      scope = setScopeForGroupKeyword(userId, scope)
+    }
+    if (scope in state && key in state[scope].scratch) {
       delete state[scope].scratch[key];
     }
   }


### PR DESCRIPTION
Ticket - https://ccp.sys.comcast.net/browse/SYSTEST-9348
As part of this ticket, implemented changes to support
- Allowing a "group" keyword to be passed for "scope" for all ctx.set(), ctx.get() and ctx.delete() functions
- When passed, the group of the userId that is INVOKING the YAML will be used as the "scope" for that call
- If the userId does not contain a group, a warning should be logged and full userId is used instead