### PR TITLE
SYSTEST-9379-Remove branding references from MF

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -70,7 +70,7 @@ run `node cli.mjs --getStatus`
 
 To add user :
 run `node cli.mjs --addUser <userId>`
-example: node cli.mjs --addUser "123~A#netflix"
+example: node cli.mjs --addUser "123~A#appId1"
 
 ## Downloading JSON/YAML overrides from a git repository
 

--- a/docs/MFScope.md
+++ b/docs/MFScope.md
@@ -15,14 +15,14 @@ The following format will be used to determine these fields from within a userId
 | --------------- | ---- | ----- | ------- |
 | 123             | 123  | N/A   | N/A     |
 | 123~A           | 123  | ~A    | N/A     |
-| 123~A#netflix   | 123  | ~A    | netflix |
-| 123#netflix     | 123  | N/A   | netflix |
+| 123~A#appId1    | 123  | ~A    | appId1  |
+| 123#appId1      | 123  | N/A   | appId1  |
 
 There will also be a "global" user. This is a reserved userId representing the global state across all users and groups.
 
 All users and appIds are unique:
 - Two users with same user part cannot exist (if "123~A" exists, "123~B" cannot exist).
-- Two users with same appId cannot exist (if "123#netflix" exists, "456#netflix" cannot exist).
+- Two users with same appId cannot exist (if "123#appId1" exists, "456#appId1" cannot exist).
 
 Example:
 
@@ -121,12 +121,12 @@ curl --location --request PUT 'http://localhost:3333/api/v1/state' \
 	}'
 ```
 
-- **To set state for "123~A#netflix" user via HTTP, use below curl command :**
+- **To set state for "123~A#appId1" user via HTTP, use below curl command :**
 
 ```
 curl --location --request PUT 'http://localhost:3333/api/v1/state' \
 	--header 'content-type: application/json'  \
-	--header 'x-mockfirebolt-userid: 123~A#netflix'  \
+	--header 'x-mockfirebolt-userid: 123~A#appId1'  \
 	--data-raw '{
 	    "state": {
 	        " ~A ": {

--- a/docs/UserGroups.md
+++ b/docs/UserGroups.md
@@ -40,6 +40,6 @@ To use user groups:
 
 #AppID
 
-If a User ID value is of the form "<userId>\~<groupName>\#<appId>" or "<userId>\#<appId>, the part after "#" is treated as the appId associated with the user. For example, in "123~A#netflix" netflix is the appId.
+If a User ID value is of the form "<userId>\~<groupName>\#<appId>" or "<userId>\#<appId>, the part after "#" is treated as the appId associated with the user. For example, in "123~A#appId1" appId1 is the appId.
 
-Only one user can be associated with an appId (for example, if 123#netflix exist, 456#netflix cannot exist).
+Only one user can be associated with an appId (for example, if 123#appId1 exist, 456#appId1 cannot exist).

--- a/server/test/suite/stateManagement.test.mjs
+++ b/server/test/suite/stateManagement.test.mjs
@@ -37,25 +37,25 @@ test(`stateManagement.addUser works properly`, () => {
 });
 
 test(`stateManagement.addUser works properly for same user`, () => {
-  const userId = "456~A#netflix";
+  const userId = "456~A#appId1";
   expect( stateManagement.addUser(userId).isSuccess ).toEqual(true);
   stateManagement.addUser(userId);
-  const userId1 = "456~A#amazon";
+  const userId1 = "456~A#appId3";
   expect(stateManagement.addUser(userId1).isSuccess).toEqual(false);
 });
 
 test(`stateManagement.addUser works properly for same appId`, () => {
-  const userId2 = "789~A#netflix";
+  const userId2 = "789~A#appId1";
   expect(stateManagement.addUser(userId2).isSuccess).toEqual(false);
 });
 
 test(`stateManagement.addUser works properly for same user without group`, () => {
-  stateManagement.addUser("111#youtube");
-  const userId3 = "111#amazon";
+  stateManagement.addUser("111#appId2");
+  const userId3 = "111#appId3";
   const result3 = stateManagement.addUser(userId3);
   expect(result3.isSuccess).toEqual(false);
 
-  const userId4 = "222#youtube";
+  const userId4 = "222#appId2";
   const result4 = stateManagement.addUser(userId4);
   expect(result4.isSuccess).toEqual(false);
 });
@@ -63,10 +63,10 @@ test(`stateManagement.addUser works properly for same user without group`, () =>
 
 test(`stateManagement.getUserId works properly`, () => {
   const userId = "456";
-  expect(stateManagement.getUserId(userId)).toEqual("456~A#netflix");
+  expect(stateManagement.getUserId(userId)).toEqual("456~A#appId1");
 
-  const userId2 = "youtube"
-  expect(stateManagement.getUserId(userId2)).toEqual("111#youtube");
+  const userId2 = "appId2"
+  expect(stateManagement.getUserId(userId2)).toEqual("111#appId2");
 
   const userId3 = "~A"
   expect(stateManagement.getUserId(userId3)).toEqual("~A");

--- a/server/test/suite/userManagement.test.mjs
+++ b/server/test/suite/userManagement.test.mjs
@@ -144,7 +144,7 @@ test(`userManagement.addUser works properly for same user`, () => {
   const userId = "456~A#sampleApp";
   expect( userManagement.addUser(userId)).toEqual(true);
   userManagement.addUser(userId);
-  const userId1 = "456~A#amazon";
+  const userId1 = "456~A#appId3";
   const expectedResult = false;
   const result1 = userManagement.addUser(userId1);
   expect(result1).toEqual(expectedResult);
@@ -165,13 +165,13 @@ test(`userManagement.addUser works properly for same user same appId`, () => {
 });
 
 test(`userManagement.addUser works properly for same user without group`, () => {
-  userManagement.addUser("111#youtube");
-  const userId3 = "111#amazon";
+  userManagement.addUser("111#appId2");
+  const userId3 = "111#appId3";
   const expectedResult3 = false
   const result3 = userManagement.addUser(userId3);
   expect(result3).toEqual(expectedResult3);
 
-  const userId4 = "222#youtube";
+  const userId4 = "222#appId2";
   const expectedResult4 = false
   const result4 = userManagement.addUser(userId4);
   expect(result4).toEqual(expectedResult4);
@@ -192,7 +192,7 @@ test(`userManagement.addUser works properly for same user same appId but differe
 });
 
 test(`userManagement.addUser works properly for different user different appId but same group`, () => {
-  const userId = "999~A#hulu";
+  const userId = "999~A#appId4";
   const expectedResult =true
   const result = userManagement.addUser(userId)
   expect(result).toEqual(expectedResult);


### PR DESCRIPTION
In several places in Mock Firebolt (Documentation, tests etc) there are references to real-world applications that might be used in MF (Ex: "netflix", "youtube"). As part of this ticket, 

- Removed references to non-Comcast applications inside of any Mock Firebolt code.

- Replaced such references with generic names
Ticket - https://ccp.sys.comcast.net/browse/SYSTEST-9379