### PR TITLE
Support JsonRPC structure for events - Part II

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -1,9 +1,12 @@
-Mock Firebolt: Events: Misc Notes
-=================================
+# Mock Firebolt: Events: Misc Notes
 
-Example event request, event ack, and event
+This document covers the flow of event registration, acknowledgement, and actual event messages in the Mock Firebolt framework. It also explains the configuration used to manage event messages.
+
+## Flow of Events
 
 ### Event Request
+
+An event request is a message from a client to register for an event. Below is an example of an event request message:
 
 ```
 {"jsonrpc":"2.0","method":"lifecycle.onInactive","params":{"listen":true},"id":1}
@@ -11,12 +14,29 @@ Example event request, event ack, and event
 
 ### Event Acknowledgement
 
+Once the server has successfully registered the client for the specified event, it optionally sends back an acknowledgement message. Here is an example:
+
 ```
 {"jsonrpc":"2.0","result":{"listening":true, "event":"lifecycle.onInactive"},"id":1}
 ```
 
 ### Event
 
+When the registered event occurs, the server sends an event message to the client. Here is an example of an event message:
+
 ```
 {"jsonrpc":"2.0","result":{"state":"inactive","previous":"foreground"}, "id":1}
 ```
+
+## Configuration
+The configuration used to manage events is found in the `.mf.config.json` file under the `eventConfig` key. Here is an explanation of each field:
+
+* registrationMessage: This defines the search pattern to identify registration messages and the method to be used. The search pattern is a regular expression. The method key is a json path.
+
+* unRegistrationMessage: Similar to registrationMessage, this defines the search pattern to identify unregistration messages and the method to be used.
+
+* registrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully registers for an event. It is a Handlebars template string where metadata placeholders get replaced with actual values.
+
+* unRegistrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully unregisters from an event. It is similar to registrationAck.
+
+* event (Optional): This is the template for the actual event message sent when the registered event occurs. It is a Handlebars template where placeholders get replaced with actual values.

--- a/docs/Events.md
+++ b/docs/Events.md
@@ -1,6 +1,6 @@
 # Mock Firebolt: Events: Misc Notes
 
-This document covers the flow of event registration, acknowledgement, and actual event messages in the Mock Firebolt framework. It also explains the configuration used to manage event messages.
+This document covers the flow of event registration, acknowledgement, and actual event messages in the Mock Firebolt framework. It also explains the configuration used to manage event messages and walks you through a typical flow using default configurations.
 
 ## Flow of Events
 
@@ -29,14 +29,72 @@ When the registered event occurs, the server sends an event message to the clien
 ```
 
 ## Configuration
+
 The configuration used to manage events is found in the `.mf.config.json` file under the `eventConfig` key. Here is an explanation of each field:
 
-* registrationMessage: This defines the search pattern to identify registration messages and the method to be used. The search pattern is a regular expression. The method key is a json path.
+- registrationMessage: This defines the search pattern to identify registration messages and the method to be used. The search pattern is a regular expression. The method key is a json path.
 
-* unRegistrationMessage: Similar to registrationMessage, this defines the search pattern to identify unregistration messages and the method to be used.
+- unRegistrationMessage: Similar to registrationMessage, this defines the search pattern to identify unregistration messages and the method to be used.
 
-* registrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully registers for an event. It is a Handlebars template string where metadata placeholders get replaced with actual values.
+- registrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully registers for an event. It is a Handlebars template string where metadata placeholders get replaced with actual values.
 
-* unRegistrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully unregisters from an event. It is similar to registrationAck.
+- unRegistrationAck (Optional): This is the template for the acknowledgement message sent when a client successfully unregisters from an event. It is similar to registrationAck.
 
-* event (Optional): This is the template for the actual event message sent when the registered event occurs. It is a Handlebars template where placeholders get replaced with actual values.
+- event (Optional): This is the template for the actual event message sent when the registered event occurs. It is a Handlebars template where placeholders get replaced with actual values.
+
+## Example Flow using Default Config
+
+The `.mf.config.SAMPLE.json` file contains default configuration for managing events. Here's how a typical flow works with these configurations.
+
+1. A client sends a registration request with the method `device.onNameChanged`.
+
+```
+{"jsonrpc":"2.0","method":"device.onNameChanged","params":{"listen":true},"id":7}
+```
+
+2. The Mock Firebolt server receives the request and identifies it as a registration request based on the registrationMessage regex in the config. Mock Firebolt also determines the event method through its json path that is either provided optionally in `registrationMessage.method` or by using the default value of `$.method`.
+
+```
+"registrationMessage": {
+  "searchRegex": "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":true.*).*\\.on\\S*",
+  "method": "$.method"
+}
+```
+
+3. If registrationAck is present in the config, the server generates an acknowledgement message using the registrationAck template. It replaces placeholders like {{registration.id}} and {{method}} with actual values from the request.
+
+```
+// Handlebars config
+{\"jsonrpc\":\"2.0\",\"id\":{{registration.id}},\"result\":{\"listening\":true,\"event\":\"{{method}}\"}}
+
+// Actual result
+{"jsonrpc":"2.0","id":7,"result":{"listening":true,"event":"device.onNameChanged"}}
+
+```
+
+4. Send a mock `device.onNameChanged` event using the API.
+
+```
+curl --location --request POST 'http://localhost:3333/api/v1/broadcastEvent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "method": "device.onDeviceNameChanged",
+    "result": "NEW-DEVICE-NAME-1"
+}'
+```
+
+5. Mock Firebolt receives the mock event and generates an event message based off of the Handlebars template provided in `eventConfig.event`.
+
+When the event `device.onNameChanged` occurs, the server generates an event message using the event template if present. It replaces placeholders with actual event data. For instance, {{resultAsJson}} would be replaced with the actual event data, serialized as a JSON string.
+
+```
+// Handlebars config
+{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}
+
+// Actual result
+{"result": "NEW-DEVICE-NAME-1","id":7,"jsonrpc":"2.0"}
+```
+
+In the Handlebars templates, you can access any data from the event metadata using the dot notation. For instance, you can use {{metadata.params.id}} to access the id from the params object in the metadata.
+
+This example flow should give you an understanding of how to customize the event configurations to suit your needs. Remember, the placeholders in the Handlebars templates correspond to the data in the event metadata, and you can use dot notation to access nested properties.

--- a/docs/Events.md
+++ b/docs/Events.md
@@ -95,6 +95,6 @@ When the event `device.onNameChanged` occurs, the server generates an event mess
 {"result": "NEW-DEVICE-NAME-1","id":7,"jsonrpc":"2.0"}
 ```
 
-In the Handlebars templates, you can access any data from the event metadata using the dot notation. For instance, you can use {{metadata.params.id}} to access the id from the params object in the metadata.
+In the Handlebars templates, you can access data from the event registration, unregistration, and the event itself, which we collectively refer to as metadata. You can use dot notation to access specific pieces of data. For instance, you can use {{registration.id}} to access the id from the registration object in the metadata. Similarly, you can access information from unregistration and event metadata objects.
 
 This example flow should give you an understanding of how to customize the event configurations to suit your needs. Remember, the placeholders in the Handlebars templates correspond to the data in the event metadata, and you can use dot notation to access nested properties.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebolt-js/sdk": "^0.9.0",
+        "@firebolt-js/sdk": "*",
         "@formschema/native": "^2.0.0-beta.6",
         "ajv": "^6.12.6",
         "body-parser": "^1.19.0",
@@ -19,6 +19,7 @@
         "express-handlebars": "^6.0.2",
         "ip": "^1.1.8",
         "js-yaml": "^4.1.0",
+        "jsonpath": "^1.1.1",
         "lodash-es": "^4.17.21",
         "moment": "^2.29.1",
         "nopt": "^5.0.0",
@@ -3440,6 +3441,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "node_modules/deepmerge": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
@@ -3686,11 +3692,31 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3699,11 +3725,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3845,6 +3878,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6490,6 +6528,28 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonpath/node_modules/esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/junk": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
@@ -6524,6 +6584,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6967,6 +7039,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7197,6 +7285,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -7838,6 +7934,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dependencies": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8124,6 +8228,17 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -8197,6 +8312,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -8397,6 +8517,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -11051,6 +11179,11 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "deepmerge": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
@@ -11242,17 +11375,32 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -11372,6 +11520,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fb-watchman": {
       "version": "2.0.2",
@@ -13306,6 +13459,23 @@
         "universalify": "^2.0.0"
       }
     },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A=="
+        }
+      }
+    },
     "junk": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
@@ -13329,6 +13499,15 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -13666,6 +13845,19 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -13829,6 +14021,11 @@
           "dev": true
         }
       }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "pretty-format": {
       "version": "28.1.3",
@@ -14331,6 +14528,14 @@
         }
       }
     },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -14543,6 +14748,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -14592,6 +14805,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -14729,6 +14947,11 @@
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "express-handlebars": "^6.0.2",
+        "handlebars": "^4.7.7",
         "ip": "^1.1.8",
         "js-yaml": "^4.1.0",
         "jsonpath": "^1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-handlebars": "^6.0.2",
+    "handlebars": "^4.7.7",
     "ip": "^1.1.8",
     "js-yaml": "^4.1.0",
     "jsonpath": "^1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -51,12 +51,13 @@
     "express": "^4.17.1",
     "express-handlebars": "^6.0.2",
     "ip": "^1.1.8",
+    "js-yaml": "^4.1.0",
+    "jsonpath": "^1.1.1",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.1",
     "nopt": "^5.0.0",
     "tmp": "^0.2.1",
     "uuid": "^8.3.2",
-    "js-yaml":"^4.1.0",
     "ws": "^8.2.3"
   },
   "optionalDependencies": {

--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -42,6 +42,7 @@
       },
       "registrationAck": "{\"jsonrpc\":\"2.0\",\"id\":{{registration.id}},\"result\":{\"listening\":true,\"event\":\"{{method}}\"}}",
       "unRegistrationAck": "{\"jsonrpc\":\"2.0\",\"id\":{{unRegistration.id}},\"result\":{\"listening\":false,\"event\":\"{{method}}\"}}",
-      "event": "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}"
+      "event": "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}",
+      "eventType": "Firebolt"
     }
 }

--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -36,9 +36,12 @@
         "searchRegex": "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":true.*).*\\.on\\S*",
         "method": "$.method"
       },
-      "unRegistrationMessage" : {
+      "unRegistrationMessage": {
         "searchRegex": "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":false.*).*\\.on\\S*",
         "method": "$.method"
-      }
+      },
+      "registrationAck": "{\"jsonrpc\":\"2.0\",\"id\":{{registration.id}},\"result\":{\"listening\":true,\"event\":\"{{method}}\"}}",
+      "unRegistrationAck": "{\"jsonrpc\":\"2.0\",\"id\":{{unRegistration.id}},\"result\":{\"listening\":false,\"event\":\"{{method}}\"}}",
+      "event": "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}"
     }
 }

--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -29,5 +29,16 @@
             "enabled": false
         }
 
-    ]
+    ],
+
+    "eventConfig": {
+      "registrationMessage": {
+        "searchRegex": "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":true.*).*\\.on\\S*",
+        "method": "$.method"
+      },
+      "unRegistrationMessage" : {
+        "searchRegex": "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":false.*).*\\.on\\S*",
+        "method": "$.method"
+      }
+    }
 }

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -59,21 +59,23 @@ const eventListenerMap = {};
  * @returns {void}
 */
 function registerEventListener(userId, metadata, ws) {
-  const { registration, event } = metadata;
+  const { registration, method } = metadata;
+
   if (!eventListenerMap[userId]) {
     eventListenerMap[userId] = {};
   }
 
-  if (!eventListenerMap[userId][event]) {
-    eventListenerMap[userId][event] = { id: registration.id, wsArr: [], metadata };
+  if (!eventListenerMap[userId][method]) {
+    // id: registration.id will be removed in part 2
+    eventListenerMap[userId][method] = { id: registration.id, wsArr: [], metadata };
   }
 
   // Check if ws is already in the wsArr before pushing
-  if (!eventListenerMap[userId][event].wsArr.includes(ws)) {
-    eventListenerMap[userId][event].wsArr.push(ws);
+  if (!eventListenerMap[userId][method].wsArr.includes(ws)) {
+    eventListenerMap[userId][method].wsArr.push(ws);
   }
 
-  logger.debug(`Registered event listener mapping: ${userId}:${event}:${registration.id}`);
+  logger.debug(`Registered event listener mapping: ${userId}:${method}:${registration.id}`);
 }
 
 // Return true if at least one user in the user’s group is registered for the given method
@@ -106,21 +108,21 @@ function getRegisteredEventListener(userId, method) {
  * @returns {void}
 */
 function deregisterEventListener(userId, metadata, ws) {
-  const { event } = metadata;
-  if (!eventListenerMap[userId] || !eventListenerMap[userId][event]) {
+  const { method } = metadata;
+  if (!eventListenerMap[userId] || !eventListenerMap[userId][method]) {
     return;
   }
 
-  const wsArr = eventListenerMap[userId][event].wsArr;
+  const wsArr = eventListenerMap[userId][method].wsArr;
   const wsIndex = wsArr.findIndex((item) => item === ws);
 
   if (wsIndex !== -1) {
     wsArr.splice(wsIndex, 1);
-    logger.debug(`Deregistered event listener mapping: ${userId}:${event}`);
+    logger.debug(`Deregistered event listener mapping: ${userId}:${method}`);
   }
 
   if (wsArr.length === 0) {
-    delete eventListenerMap[userId][event];
+    delete eventListenerMap[userId][method];
   }
 }
 
@@ -147,8 +149,8 @@ function extractEventData(oMsg, config, isOn) {
   const methodName = extractedMethod[0];
   const metadata = {
     registration: {},
-    event: methodName,
     unRegistration: {},
+    method: methodName
   };
 
    // If isOn is true, add oMsg to metadata.registration

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -111,7 +111,7 @@ function deregisterEventListener(userId, metadata, ws) {
     return;
   }
 
-  const wsArr = eventListenerMap[userId][oMsg.method].wsArr;
+  const wsArr = eventListenerMap[userId][event].wsArr;
   const wsIndex = wsArr.findIndex((item) => item === ws);
 
   if (wsIndex !== -1) {
@@ -376,7 +376,10 @@ export const testExports = {
   getRegisteredEventListener,
   isAnyRegisteredInGroup,
   sendBroadcastEvent,
-  emitResponse
+  emitResponse, 
+  extractEventData,
+  isEventListenerOnMessage,
+  isEventListenerOffMessage
 }
 
 export {

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -60,15 +60,14 @@ const eventListenerMap = {};
  * @returns {void}
 */
 function registerEventListener(userId, metadata, ws) {
-  const { registration, method } = metadata;
+  const { method } = metadata;
 
   if (!eventListenerMap[userId]) {
     eventListenerMap[userId] = {};
   }
 
   if (!eventListenerMap[userId][method]) {
-    // id: registration.id will be removed in part 2
-    eventListenerMap[userId][method] = { id: registration.id, wsArr: [], metadata };
+    eventListenerMap[userId][method] = { wsArr: [], metadata };
   }
 
   // Check if ws is already in the wsArr before pushing

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -278,7 +278,6 @@ function emitResponse(finalResult, msg, userId, method) {
     result: finalResult,
     resultAsJson: JSON.stringify(finalResult)
   };
-  console.log(templateData)
 
   // If event template config does not exist, use default template which just returns the result
   const defaultEventTemplate = `{"result":{{{resultAsJson}}}{{~"}}"~}}}`;

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -171,12 +171,8 @@ function extractEventData(oMsg, config, isOn) {
 function isEventListenerMessage(oMsg, config) {
   // Call extractEventData and store the result
   const eventData = extractEventData(oMsg, config);
-
-  if (eventData !== false) {
-    return true;
-  }
-
-  return false;
+  
+  return (eventData !== false);
 }
 
 /**

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -287,7 +287,12 @@ function emitResponse(finalResult, msg, userId, method) {
 
   wsArr.forEach((ws) => {
     ws.send(eventMessage);
-    logger.info(`${msg}: Sent event message to user ${userId}: ${eventMessage}`);
+    // Check if eventType is included in config
+    if (eventConfig.eventType) {
+      logger.info(`${msg}: Sent ${eventConfig.eventType} message to user ${userId}: ${eventMessage}`);
+    } else {
+      logger.info(`${msg}: Sent event message to user ${userId}: ${eventMessage}`);
+    }
   });
 }
 

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -75,7 +75,7 @@ function registerEventListener(userId, metadata, ws) {
     eventListenerMap[userId][method].wsArr.push(ws);
   }
 
-  logger.debug(`Registered event listener mapping: ${userId}:${method}:${registration.id}`);
+  logger.debug(`Registered event listener mapping: ${userId}:${method}`);
 }
 
 // Return true if at least one user in the user’s group is registered for the given method
@@ -134,7 +134,8 @@ function deregisterEventListener(userId, metadata, ws) {
  * @returns {object | false} - An object containing the extracted event data or false if the extraction fails.
 */
 function extractEventData(oMsg, config, isOn) {
-  const { searchRegex, method } = config;
+  const searchRegex = config.searchRegex;
+  const method = config.method || '$.method';
 
   if (!new RegExp(searchRegex).test(JSON.stringify(oMsg))) {
     return false;
@@ -163,6 +164,7 @@ function extractEventData(oMsg, config, isOn) {
 
   return metadata;
 }
+
 
 /**
  * Determines if the given object message is an event listener message.

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -83,6 +83,8 @@ async function handleMessage(message, userId, ws) {
   }
 
   // Handle JSON-RPC messages that are event listener enable requests
+  // First we extract event data from the message using the registrationMessage config
+  // Then we register the event listener for the specified user and WebSocket with the extracted metadata
   if ( events.isEventListenerOnMessage(oMsg) ) {
     events.sendEventListenerAck(userId, ws, oMsg);
     const eventMetadata = events.extractEventData(oMsg, eventConfig.registrationMessage, true);
@@ -91,6 +93,8 @@ async function handleMessage(message, userId, ws) {
   }
   
   // Handle JSON-RPC messages that are event listener disable requests
+  // First we extract event data from the message using the unRegistrationMessage config
+  // Then we deregister the event listener for the specified user and WebSocket with the extracted metadata
   if ( events.isEventListenerOffMessage(oMsg) ) {
     const eventMetadata = events.extractEventData(oMsg, eventConfig.unRegistrationMessage, false);
     events.deregisterEventListener(userId, eventMetadata, ws);

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -83,14 +83,14 @@ async function handleMessage(message, userId, ws) {
 
   if ( events.isEventListenerOnMessage(oMsg) ) {
     events.sendEventListenerAck(userId, ws, oMsg);
-    events.registerEventListener(userId, oMsg);
+    events.registerEventListener(userId, oMsg, ws);
     return;
   }
 
   // Handle JSON-RPC messages that are event listener disable requests
 
   if ( events.isEventListenerOffMessage(oMsg) ) {
-    events.deregisterEventListener(userId, oMsg);
+    events.deregisterEventListener(userId, oMsg, ws);
     return;
   }
 

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -30,6 +30,9 @@ import { methodTriggers } from './triggers.mjs';
 import { addCall, updateCallWithResponse } from './sessionManagement.mjs';
 import * as proxyManagement from './proxyManagement.mjs';
 import * as conduit from './conduit.mjs';
+import { config } from './config.mjs';
+
+const { dotConfig: { eventConfig } } = config;
 
 function fSuccess(msg, onMethod, result) {
   logger.info(`${msg}: Sent event ${onMethod} with result ${JSON.stringify(result)}`)
@@ -80,17 +83,17 @@ async function handleMessage(message, userId, ws) {
   }
 
   // Handle JSON-RPC messages that are event listener enable requests
-
   if ( events.isEventListenerOnMessage(oMsg) ) {
     events.sendEventListenerAck(userId, ws, oMsg);
-    events.registerEventListener(userId, oMsg, ws);
+    const eventMetadata = events.extractEventData(oMsg, eventConfig.registrationMessage, true);
+    events.registerEventListener(userId, eventMetadata, ws);
     return;
   }
-
+  
   // Handle JSON-RPC messages that are event listener disable requests
-
   if ( events.isEventListenerOffMessage(oMsg) ) {
-    events.deregisterEventListener(userId, oMsg, ws);
+    const eventMetadata = events.extractEventData(oMsg, eventConfig.unRegistrationMessage, false);
+    events.deregisterEventListener(userId, eventMetadata, ws);
     return;
   }
 

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -87,42 +87,34 @@ async function handleMessage(message, userId, ws) {
   // Then we register the event listener for the specified user and WebSocket with the extracted metadata
   if (events.isEventListenerOnMessage(oMsg)) {
     const eventMetadata = events.extractEventData(oMsg, eventConfig.registrationMessage, true);
+
+    events.registerEventListener(userId, eventMetadata, ws);
   
-    // Only send ack messages and return if not in proxy mode
+    // Only perform additional actions if not in proxy mode
     if (!process.env.proxy) {
       // If registrationAck config is included, send ack message
       if (eventConfig.registrationAck) {
         events.sendEventListenerAck(userId, ws, eventMetadata);
       }
-  
-      events.registerEventListener(userId, eventMetadata, ws);
       return;
     }
-    // If in proxy mode, just register the event listener without sending ack messages or returning
-    else {
-      events.registerEventListener(userId, eventMetadata, ws);
-    }
-  }  
-  
+  }
+   
   // Handle JSON-RPC messages that are event listener disable requests
   // First we extract event data from the message using the unRegistrationMessage config
   // Then we deregister the event listener for the specified user and WebSocket with the extracted metadata
   if (events.isEventListenerOffMessage(oMsg)) {
     const eventMetadata = events.extractEventData(oMsg, eventConfig.unRegistrationMessage, false);
+
+    events.deregisterEventListener(userId, eventMetadata, ws);
   
-    // Only send ack messages and return if not in proxy mode
+    // Only perform additional actions if not in proxy mode
     if (!process.env.proxy) {
       // If unRegistrationAck config is included, send ack message
       if (eventConfig.unRegistrationAck) {
         events.sendUnRegistrationAck(userId, ws, eventMetadata);
       }
-      
-      events.deregisterEventListener(userId, eventMetadata, ws);
       return;
-    }
-    // If in proxy mode, just deregister the event listener without sending ack messages or returning
-    else {
-      events.deregisterEventListener(userId, eventMetadata, ws);
     }
   }
 

--- a/server/src/proxyManagement.mjs
+++ b/server/src/proxyManagement.mjs
@@ -95,7 +95,7 @@ function setupOutgoingWs(returnWs, userId) {
 }
 
 function getResponseMessageFromProxy(returnWs) {
-  let timeout = 30000;
+  let timeout = 10000;
   let counter = 0;
   let interval = 100;
   return new Promise((res, rej) => {

--- a/server/src/proxyManagement.mjs
+++ b/server/src/proxyManagement.mjs
@@ -95,7 +95,7 @@ function setupOutgoingWs(returnWs, userId) {
 }
 
 function getResponseMessageFromProxy(returnWs) {
-  let timeout = 10000;
+  let timeout = 30000;
   let counter = 0;
   let interval = 100;
   return new Promise((res, rej) => {

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -75,7 +75,8 @@ test(`config works properly`, () => {
         },
         registrationAck: "{\"jsonrpc\":\"2.0\",\"id\":{{registration.id}},\"result\":{\"listening\":true,\"event\":\"{{method}}\"}}",
         unRegistrationAck: "{\"jsonrpc\":\"2.0\",\"id\":{{unRegistration.id}},\"result\":{\"listening\":false,\"event\":\"{{method}}\"}}",
-        event: "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}"
+        event: "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}",
+        eventType: "Firebolt"
       }
     },
   };

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -69,10 +69,13 @@ test(`config works properly`, () => {
           searchRegex: "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":true.*).*\\.on\\S*",
           method: "$.method"
         },
-        unRegistrationMessage : {
+        unRegistrationMessage: {
           searchRegex: "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":false.*).*\\.on\\S*",
           method: "$.method"
-        }
+        },
+        registrationAck: "{\"jsonrpc\":\"2.0\",\"id\":{{registration.id}},\"result\":{\"listening\":true,\"event\":\"{{method}}\"}}",
+        unRegistrationAck: "{\"jsonrpc\":\"2.0\",\"id\":{{unRegistration.id}},\"result\":{\"listening\":false,\"event\":\"{{method}}\"}}",
+        event: "{\"result\":{{{resultAsJson}}},\"id\":{{registration.id}},\"jsonrpc\":\"2.0\"}"
       }
     },
   };

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -64,6 +64,16 @@ test(`config works properly`, () => {
           name: "discovery",
         },
       ],
+      eventConfig: {
+        registrationMessage: {
+          searchRegex: "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":true.*).*\\.on\\S*",
+          method: "$.method"
+        },
+        unRegistrationMessage : {
+          searchRegex: "(?=.*\\\"method\\\".*)(?=.*\\\"listen\\\":false.*).*\\.on\\S*",
+          method: "$.method"
+        }
+      }
     },
   };
   expect(config).toEqual(expectedResult);

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -78,7 +78,6 @@ test(`events.getRegisteredEventListener works properly`, () => {
     methodName
   );
   const expectedResult = {
-    id: 12,
     metadata: {
       method: methodName,
       registration: { id: 12 },

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -184,11 +184,30 @@ test(`events.isEventListenerOffMessage works properly`, () => {
 
 test(`events.sendEventListenerAck works properly`, () => {
   const spy = jest.spyOn(logger, "debug");
-  const oMsgdummy = { method: "lifecycle.onInactive", id: 12 };
-  const dummyWebSocket = { send: () => {} };
-  events.sendEventListenerAck("12345", dummyWebSocket, oMsgdummy);
+  const wsSpy = jest.fn();
+  const dummyWebSocket = { send: wsSpy };
+  const metadataDummy = { 
+    method: "lifecycle.onInactive", 
+    registration: { id: 12 } 
+  };
+  events.sendEventListenerAck("12345", dummyWebSocket, metadataDummy);
   expect(spy).toHaveBeenCalled();
+  expect(wsSpy).toHaveBeenCalled();
 });
+
+test(`events.sendUnRegistrationAck works properly`, () => {
+  const spy = jest.spyOn(logger, "debug");
+  const wsSpy = jest.fn();
+  const dummyWebSocket = { send: wsSpy };
+  const metadataDummy = { 
+    method: "lifecycle.onInactive", 
+    unRegistration: { id: 12 } 
+  };
+  events.sendUnRegistrationAck("12345", dummyWebSocket, metadataDummy);
+  expect(spy).toHaveBeenCalled();
+  expect(wsSpy).toHaveBeenCalled();
+});
+
 
 test(`events.sendEvent works properly`, () => {
   const methodName = "test",

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -368,9 +368,9 @@ test(`events.extractEventData returns correct data when searchRegex and method m
     searchRegex: /lifecycle\..*/,
     method: '$.method',
   };
-  const isOn = true;
+  const isEnabled = true;
 
-  const result = events.extractEventData(oMsg, config, isOn);
+  const result = events.extractEventData(oMsg, config, isEnabled);
 
   const expectedResult = {
     registration: oMsg,
@@ -393,9 +393,9 @@ test(`events.extractEventData returns correct data when searchRegex and method m
     searchRegex: /lifecycle\..*/,
     method: 'payload.params.method',
   };
-  const isOn = true;
+  const isEnabled = true;
 
-  const result = events.extractEventData(oMsg, config, isOn);
+  const result = events.extractEventData(oMsg, config, isEnabled);
 
   const expectedResult = {
     registration: oMsg,
@@ -416,9 +416,9 @@ test(`events.extractEventData returns false when searchRegex does not match`, ()
     searchRegex: /invalidRegex/,
     method: '$.method',
   };
-  const isOn = true;
+  const isEnabled = true;
 
-  const result = events.extractEventData(oMsg, config, isOn);
+  const result = events.extractEventData(oMsg, config, isEnabled);
 
   expect(result).toBeFalsy();
 });
@@ -434,14 +434,14 @@ test(`events.extractEventData returns false when method does not match`, () => {
     searchRegex: /lifecycle\..*/,
     method: '$.nonExistentProperty',
   };
-  const isOn = true;
+  const isEnabled = true;
 
-  const result = events.extractEventData(oMsg, config, isOn);
+  const result = events.extractEventData(oMsg, config, isEnabled);
 
   expect(result).toBeFalsy();
 });
 
-test(`events.extractEventData returns correct data when isOn is false`, () => {
+test(`events.extractEventData returns correct data when isEnabled is false`, () => {
   const oMsg = {
     method: 'lifecycle.onInactive',
     payload: {
@@ -452,9 +452,9 @@ test(`events.extractEventData returns correct data when isOn is false`, () => {
     searchRegex: /lifecycle\..*/,
     method: '$.method',
   };
-  const isOn = false;
+  const isEnabled = false;
 
-  const result = events.extractEventData(oMsg, config, isOn);
+  const result = events.extractEventData(oMsg, config, isEnabled);
 
   const expectedResult = {
     registration: {},

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -31,7 +31,8 @@ test(`events.registerEventListener works properly`, () => {
     method: "",
     id: 12,
   };
-  events.registerEventListener("12345", dummyObject);
+  const dummyWebSocket = { send: () => {} };
+  events.registerEventListener("12345", dummyObject, dummyWebSocket);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -92,7 +93,8 @@ test(`events.getRegisteredEventListener works properly if path`, () => {
 test(`events.deregisterEventListener works properly`, () => {
   const spy = jest.spyOn(logger, "debug");
   const oMsgdummy = { method: "lifecycle.onInactive", id: 12 };
-  events.deregisterEventListener(oMsgdummy);
+  const dummyWebSocket = { send: () => {} };
+  events.deregisterEventListener("12345", oMsgdummy.method, dummyWebSocket);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -177,7 +179,8 @@ test(`events.isEventListenerOffMessage works properly`, () => {
 test(`events.sendEventListenerAck works properly`, () => {
   const spy = jest.spyOn(logger, "debug");
   const oMsgdummy = { method: "lifecycle.onInactive", id: 12 };
-  events.sendEventListenerAck('12345', { send: () => {} }, oMsgdummy);
+  const dummyWebSocket = { send: () => {} };
+  events.sendEventListenerAck("12345", dummyWebSocket, oMsgdummy);
   expect(spy).toHaveBeenCalled();
 });
 
@@ -205,9 +208,11 @@ test(`events.sendEvent works properly`, () => {
       call: () => {},
     },
   };
-  events.registerEventListener("12345", dummyObject);
+  const dummyWebSocket = { send: () => {} };
+
+  events.registerEventListener("12345", dummyObject, dummyWebSocket);
   events.sendEvent(
-    { send: () => {} },
+    dummyWebSocket,
     "12345",
     methodName,
     result,
@@ -286,8 +291,9 @@ test(`events.isAnyRegisteredInGroup works properly with if path`, () => {
 });
 
 test(`events.sendBroadcastEvent works properly`, () => {
+  const dummyWebSocket = { send: () => {} };
   const result = events.testExports.sendBroadcastEvent(
-    { send: () => {} },
+    dummyWebSocket,
     "12345",
     "core",
     {},
@@ -301,12 +307,15 @@ test(`events.sendBroadcastEvent works properly`, () => {
 
 test(`events.emitResponse works properly`, () => {
   const spy = jest.spyOn(logger, "info");
-  events.testExports.emitResponse(
-    { send: () => {} },
-    {},
-    "test_msg",
-    "12345",
-    "core"
-  );
+  const listenerObject = {
+    method: "core",
+    id: 12,
+  };
+  const dummyWebSocket = { send: () => {} };
+
+  // Register the event listener first to simulate a real-world scenario
+  events.registerEventListener("12345", listenerObject, dummyWebSocket);
+
+  events.testExports.emitResponse({}, "test_msg", "12345", "core");
   expect(spy).toHaveBeenCalled();
 });


### PR DESCRIPTION
MF has the ability to trigger events either manually through the API/CLI or automatically through triggers.

In order to send and format these events, MF must keep track of which incoming users are listening. This formatting/searching/etc is currently hard-coded for the FB format. We must open up the existing event functionality to support any JsonRPC structure for events.