### PR TITLE
SYSTEST-9456-Change supportedSDKs config and compare in-use/sample co…

### DIFF
--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -3,7 +3,7 @@
 
     "multiUserConnections": "warn",
 
-    "supportedSdks": [
+    "supportedOpenRPCs": [
 
         {
             "name": "core",

--- a/server/src/commandLine.mjs
+++ b/server/src/commandLine.mjs
@@ -50,7 +50,7 @@ const knownOpts = {
   'proxy'                : String,
   'multiUserConnections': String
 };
-for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedSdks) ) {
+for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedOpenRPCs) ) {
   if ( oSdk.cliFlag ) {
     if ( ! knownOpts.hasOwnProperty(oSdk.cliFlag) ) {
       knownOpts[oSdk.cliFlag] = Boolean;
@@ -65,7 +65,7 @@ const shortHands = {
   't'     : [ '--triggers' ],
   'noval' : [ '--novalidate' ]
 };
-for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedSdks) ) {
+for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedOpenRPCs) ) {
   if ( oSdk.cliShortFlag ) {
     if ( ! shortHands.hasOwnProperty(oSdk.cliShortFlag) ) {
       shortHands[oSdk.cliShortFlag] = [ `--${oSdk.cliFlag}` ];
@@ -103,7 +103,7 @@ config.validate = mergeArrayOfStrings(config.validate, config.dotConfig.validate
 
 // Convert boolean flags for any SDKs into a simple map/dict/obj
 const sdks = {};
-for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedSdks) ) {
+for ( const [sdk, oSdk] of Object.entries(config.dotConfig.supportedOpenRPCs) ) {
   if ( parsed[oSdk.name] || oSdk.enabled ) {
     sdks[oSdk.name] = true;
   }

--- a/server/src/dotConfig.mjs
+++ b/server/src/dotConfig.mjs
@@ -59,14 +59,14 @@ function loadDotConfig() {
 }
 
 /* 
-* @function:findCreatedAndModifiedDate
+* @function:findFileCreationAndModificationTime
 * @Description: To get creation and modification time of files
 @param {String} creationDateFileName - Name of file whose creation time needs to be retrieved in seconds
 @param {String} modificationDateFileName - Name of file whose modification time needs to be retrieved in seconds
 * @Return: Array containing creation and modification time in seconds ex: [1687860231, 1687860231]
 */
 
-function findCreatedAndModifiedDate(creationDateFileName, modificationDateFileName) {
+function findFileCreationAndModificationTime(creationDateFileName, modificationDateFileName) {
   let cFile, mFile, __dirname, __filename
   __filename = fileURLToPath(import.meta.url).replace("build", "src");
   __dirname = path.dirname(__filename);
@@ -77,8 +77,8 @@ function findCreatedAndModifiedDate(creationDateFileName, modificationDateFileNa
   return [creationTimeSec, modificationTimeSec]
 }
 
-const [creationTimeSec, modificationTimeSec] = findCreatedAndModifiedDate('.mf.config.SAMPLE.json', '.mf.config.json')
-if (creationTimeSec > modificationTimeSec) {
+const [creationTimeSec, modificationTimeSec] = findFileCreationAndModificationTime('.mf.config.SAMPLE.json', '.mf.config.json')
+if (creationTimeSec >= modificationTimeSec) {
   logger.importantWarning(`Refer release notes to check for new/modified configs. You probably want to "cp src/.mf.config.SAMPLE.json src/.mf.config.json && npm run build:mf"`)
 }
 

--- a/server/src/dotConfig.mjs
+++ b/server/src/dotConfig.mjs
@@ -58,6 +58,30 @@ function loadDotConfig() {
   return dotConfig;
 }
 
+/* 
+* @function:findCreatedAndModifiedDate
+* @Description: To get creation and modification time of files
+@param {String} creationDateFileName - Name of file whose creation time needs to be retrieved in seconds
+@param {String} modificationDateFileName - Name of file whose modification time needs to be retrieved in seconds
+* @Return: Array containing creation and modification time in seconds ex: [1687860231, 1687860231]
+*/
+
+function findCreatedAndModifiedDate(creationDateFileName, modificationDateFileName) {
+  let cFile, mFile, __dirname, __filename
+  __filename = fileURLToPath(import.meta.url).replace("build", "src");
+  __dirname = path.dirname(__filename);
+  cFile = path.resolve(__dirname, creationDateFileName);
+  mFile = path.resolve(__dirname, modificationDateFileName);
+  const creationTimeSec = Math.floor(fs.statSync(cFile).birthtimeMs / 1000);
+  const modificationTimeSec = Math.floor(fs.statSync(mFile).mtimeMs / 1000);
+  return [creationTimeSec, modificationTimeSec]
+}
+
+const [creationTimeSec, modificationTimeSec] = findCreatedAndModifiedDate('.mf.config.SAMPLE.json', '.mf.config.json')
+if (creationTimeSec > modificationTimeSec) {
+  logger.importantWarning(`Refer release notes to check for new/modified configs. You probably want to "cp src/.mf.config.SAMPLE.json src/.mf.config.json && npm run build:mf"`)
+}
+
 const dotConfig = loadDotConfig();
 
 // --- Exports ---

--- a/server/src/dotConfig.mjs
+++ b/server/src/dotConfig.mjs
@@ -21,9 +21,10 @@
 'use strict';
 
 import path from 'path';
-import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { logger } from './logger.mjs';
+import { createAbsoluteFilePath, getCreationDate, getModificationDate } from './util.mjs';
+
 
 function handleError(fileName, __dirname) {
   logger.error(
@@ -36,19 +37,6 @@ function handleError(fileName, __dirname) {
       'You probably want to "cp src/.mf.config.SAMPLE.json src/.mf.config.json && npm run build:mf"'
     );
   }
-}
-/* 
-* @function:createAbsoluteFilePath
-* @Description: Create absolute filepath from given file name
-* @param {String} fileName - file name ex: .mf.config.SAMPLE.jsons
-* @Return: Absolute file path ex: D:\mock-firebolt\server\src\.mf.config.SAMPLE.json
-*/
-function createAbsoluteFilePath(fileName) {
-  let filePath, __dirname, __filename
-  __filename = fileURLToPath(import.meta.url).replace("build", "src");
-  __dirname = path.dirname(__filename);
-  filePath = path.resolve(__dirname, fileName);
-  return filePath
 }
 
 function loadDotConfig() {
@@ -70,31 +58,6 @@ function loadDotConfig() {
     process.exit(1);
   }
   return dotConfig;
-}
-
-/* 
-* @function:getCreationDate
-* @Description: To get creation date of file in seconds
-* @param {String} fileName - Name of file whose creation time needs to be retrieved in seconds
-* @Return: creation time in seconds ex: 1687860231
-*/
-
-function getCreationDate(fileName) {
-  let cFile = createAbsoluteFilePath (fileName)
-  const creationTimeSec = Math.floor(fs.statSync(cFile).birthtimeMs / 1000);
-  return creationTimeSec
-}
-
-/* 
-* @function:getModificationDate
-* @Description: To get modification date of file in seconds
-* @param {String} fileName - Name of file whose modification time needs to be retrieved in seconds
-* @Return: modification time in seconds ex: 1687860232
-*/
-function  getModificationDate(fileName) {
-  let mFile = createAbsoluteFilePath (fileName)
-  const modificationTimeSec = Math.floor(fs.statSync(mFile).mtimeMs / 1000);
-  return modificationTimeSec
 }
 
 const creationTimeSec = getCreationDate('.mf.config.SAMPLE.json')

--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -68,8 +68,8 @@ function getMeta() {
 }
 
 function getMethod(methodName) {
-  for ( let ii = 0; ii < config.dotConfig.supportedSdks.length; ii += 1 ) {
-    const sdkName = config.dotConfig.supportedSdks[ii].name;
+  for ( let ii = 0; ii < config.dotConfig.supportedOpenRPCs.length; ii += 1 ) {
+    const sdkName = config.dotConfig.supportedOpenRPCs[ii].name;
     if (config.app.allowMixedCase){
       methodName = toLowerCase(methodName);
     }
@@ -90,8 +90,8 @@ function isMethodKnown(methodName) {
 }
 
 function getSchema(schemaName) {
-  for ( const ii = 0; ii < config.dotConfig.supportedSdks.length; ii += 1 ) {
-    const sdkName = config.dotConfig.supportedSdks[ii].name;
+  for ( const ii = 0; ii < config.dotConfig.supportedOpenRPCs.length; ii += 1 ) {
+    const sdkName = config.dotConfig.supportedOpenRPCs[ii].name;
     if ( schemaName in meta[sdkName].components.schemas ) { return meta[sdkName].components.schemas[schemaName]; }
   }
   return undefined;
@@ -263,7 +263,7 @@ async function readSdkJsonFileIfEnabled(sdkName) {
   let url, fileUrl;
   if ( isSdkEnabled(sdkName) ) {
     try {
-      const oSdk = config.dotConfig.supportedSdks.find((oSdk) => { return ( oSdk.name === sdkName ); });
+      const oSdk = config.dotConfig.supportedOpenRPCs.find((oSdk) => { return ( oSdk.name === sdkName ); });
       if ( oSdk.fileName ) {
         const openRpcFileName = oSdk.fileName;
         if ( path.isAbsolute(openRpcFileName) || openRpcFileName.startsWith('~') ) {
@@ -305,7 +305,7 @@ async function readAllEnabledSdkJsonFiles() {
     await readSdkJsonFileIfEnabled('mock');
   }
   else {
-    await Promise.all(config.dotConfig.supportedSdks.map(async (oSdk) => {
+    await Promise.all(config.dotConfig.supportedOpenRPCs.map(async (oSdk) => {
       const sdkName = oSdk.name;
       await readSdkJsonFileIfEnabled(sdkName);
     }));
@@ -314,7 +314,7 @@ async function readAllEnabledSdkJsonFiles() {
 
 function buildMethodMapsForAllEnabledSdks() {
   // Build faster-performing maps for methods (vs. openrpc.methods array)
-  config.dotConfig.supportedSdks.forEach(function(oSdk) {
+  config.dotConfig.supportedOpenRPCs.forEach(function(oSdk) {
     const sdkName = oSdk.name;
     if ( isSdkEnabled(sdkName) ) {
       methodMaps[sdkName] = buildMethodMap(meta[sdkName]);
@@ -324,14 +324,14 @@ function buildMethodMapsForAllEnabledSdks() {
 
 // --- Module-level Code ---
 
-// Will contain one key for each API enabled (See .mf.config.json::supportedSdks)
+// Will contain one key for each API enabled (See .mf.config.json::supportedOpenRPCs)
 // The value for each key will be an object containing keys: openrpc, info, methods, and components (contents of firebolt-xxx-sdk.json file)
 const rawMeta = {};
 
 // Same as above, but $refs have been dereferenced; this is the main datastructure used here
 let meta = {};
 
-// Will contain one key for each API enabled (See .mf.config.json::supportedSdks)
+// Will contain one key for each API enabled (See .mf.config.json::supportedOpenRPCs)
 // The value for each key will be an object with keys for each method
 const methodMaps = {};
 

--- a/server/src/fireboltOpenRpcDereferencing.mjs
+++ b/server/src/fireboltOpenRpcDereferencing.mjs
@@ -122,7 +122,7 @@ function dereferenceSchemas(metaForSdk, methodName) {
 
 function dereferenceMeta(_meta) {
   const meta = JSON.parse(JSON.stringify(_meta)); // Deep copy
-  config.dotConfig.supportedSdks.forEach(function(oSdk) {
+  config.dotConfig.supportedOpenRPCs.forEach(function(oSdk) {
     const sdkName = oSdk.name;
     if ( sdkName in meta ) {
       const metaForSdk = meta[sdkName];

--- a/server/src/routes/api/health.mjs
+++ b/server/src/routes/api/health.mjs
@@ -50,7 +50,7 @@ function healthcheck(req, res) {
     meta = fireboltOpenRpc.getMeta();
   }
 
-  config.dotConfig.supportedSdks.forEach(function(oSdk) {
+  config.dotConfig.supportedOpenRPCs.forEach(function(oSdk) {
     const sdkName = oSdk.name;
     if ( sdkManagement.isSdkEnabled(sdkName) ) {
       if ( meta[sdkName] && meta[sdkName].info ) {

--- a/server/src/sdkManagement.mjs
+++ b/server/src/sdkManagement.mjs
@@ -25,7 +25,7 @@ import * as commandLine from './commandLine.mjs';
 
 function isSdkEnabled(sdkName) {
   // Check if sdk with given name is enabled in the .mf.config.json file
-  const oSdk = config.dotConfig.supportedSdks.find((oSdk) => { return ( oSdk.name === sdkName ); });
+  const oSdk = config.dotConfig.supportedOpenRPCs.find((oSdk) => { return ( oSdk.name === sdkName ); });
   if ( oSdk && oSdk.enabled ) {
     return true;
   }

--- a/server/src/util.mjs
+++ b/server/src/util.mjs
@@ -24,6 +24,12 @@ import * as tmp from 'tmp';
 
 import { config } from './config.mjs';
 
+import { fileURLToPath } from 'url';
+
+import path from 'path';
+
+import fs from 'fs';
+
 // Use: await delay(2000);
 function delay(ms) {
   return new Promise(res => setTimeout(res, ms));
@@ -60,6 +66,46 @@ function mergeArrayOfStrings(originalFlags, overrideFlags, denyFlags) {
   return newFlags
 }
 
+/* 
+* @function:createAbsoluteFilePath
+* @Description: Create absolute filepath from given file name
+* @param {String} fileName - file name ex: .mf.config.SAMPLE.jsons
+* @Return: Absolute file path ex: D:\mock-firebolt\server\src\.mf.config.SAMPLE.json
+*/
+function createAbsoluteFilePath(fileName) {
+  let filePath, __dirname, __filename
+  __filename = fileURLToPath(import.meta.url).replace("build", "src");
+  __dirname = path.dirname(__filename);
+  filePath = path.resolve(__dirname, fileName);
+  return filePath
+}
+
+/* 
+* @function:getCreationDate
+* @Description: To get creation date of file in seconds
+* @param {String} fileName - Name of file whose creation time needs to be retrieved in seconds
+* @Return: creation time in seconds ex: 1687860231
+*/
+
+function getCreationDate(fileName) {
+  let cFile = createAbsoluteFilePath (fileName)
+  const creationTimeSec = Math.floor(fs.statSync(cFile).birthtimeMs / 1000);
+  return creationTimeSec
+}
+
+/* 
+* @function:getModificationDate
+* @Description: To get modification date of file in seconds
+* @param {String} fileName - Name of file whose modification time needs to be retrieved in seconds
+* @Return: modification time in seconds ex: 1687860232
+*/
+function  getModificationDate(fileName) {
+  let mFile = createAbsoluteFilePath (fileName)
+  const modificationTimeSec = Math.floor(fs.statSync(mFile).mtimeMs / 1000);
+  return modificationTimeSec
+}
+
+
 // --- Exports ---
 
-export { delay, randomIntFromInterval, getUserIdFromReq, createTmpFile, mergeArrayOfStrings };
+export { delay, randomIntFromInterval, getUserIdFromReq, createTmpFile, mergeArrayOfStrings, createAbsoluteFilePath, getCreationDate, getModificationDate };

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -41,7 +41,7 @@ test(`config works properly`, () => {
     dotConfig: {
       validate: ["method", "params", "response", "events"],
       multiUserConnections: 'warn',
-      supportedSdks: [
+      supportedOpenRPCs: [
         {
           cliFlag: null,
           cliShortFlag: null,


### PR DESCRIPTION
Ticket - https://ccp.sys.comcast.net/browse/SYSTEST-9456

1. Compare in-use/sample configs by accessing creation/modification date through metadata of files.
 If mf.config.SAMPLE.json is the same age/older than .mf.config.json: Do nothing. We assume the config is valid
 Else : Print a warning to the screen suggesting they look at release notes to check for new/modified configs.
 
2. Rename "supportedSDKs" in the sample config to "supportedOpenRPCs" and update all references to the same