### PR TITLE
Update openRPC URL to use latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Click the "Load Unpacked" button (top left corner of browser window)
 Navigate to the directory under browser-extensions which contains a manifest.json file and click "Select"
 ```
 
-Now you can access core/manage OpenRPC from HTTP by adding `"url": "https://meta.rdkcentral.com/firebolt/api/"` in mf.config.SAMPLE.json and copying to mf.config.json and can add `@firebolt-js/discovery-sdk` in your app's `package.json` file, import `@firebolt-js/discovery-sdk` optionally in your code in case to make discovery calls
+Now you can access core/manage OpenRPC from HTTP by adding `"url": "https://rdkcentral.github.io/firebolt/requirements/latest/specifications/firebolt-open-rpc.json"` in mf.config.SAMPLE.json and copying to mf.config.json and can add `@firebolt-js/discovery-sdk` in your app's `package.json` file, import `@firebolt-js/discovery-sdk` optionally in your code in case to make discovery calls
 
 
 # Usage (via Docker, if you prefer)

--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -9,7 +9,7 @@
             "name": "core",
             "cliFlag": null,
             "cliShortFlag": null,
-            "theBelowUrl": "Can be changed to test different versions of the firebolt-open-rpc",
+            "url_Note": "Can be changed to test different versions of the firebolt-open-rpc",
             "url": "https://rdkcentral.github.io/firebolt/requirements/latest/specifications/firebolt-open-rpc.json",
             "enabled": true
         },

--- a/server/src/.mf.config.SAMPLE.json
+++ b/server/src/.mf.config.SAMPLE.json
@@ -9,7 +9,8 @@
             "name": "core",
             "cliFlag": null,
             "cliShortFlag": null,
-            "url": "https://meta.rdkcentral.com/firebolt/api/",
+            "theBelowUrl": "Can be changed to test different versions of the firebolt-open-rpc",
+            "url": "https://rdkcentral.github.io/firebolt/requirements/latest/specifications/firebolt-open-rpc.json",
             "enabled": true
         },
 

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -47,7 +47,8 @@ test(`config works properly`, () => {
           cliFlag: null,
           cliShortFlag: null,
           enabled: true,
-          url: "https://meta.rdkcentral.com/firebolt/api/",
+          theBelowUrl: "Can be changed to test different versions of the firebolt-open-rpc",
+          url: "https://rdkcentral.github.io/firebolt/requirements/latest/specifications/firebolt-open-rpc.json",
           name: "core",
         },
         {

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -47,7 +47,7 @@ test(`config works properly`, () => {
           cliFlag: null,
           cliShortFlag: null,
           enabled: true,
-          theBelowUrl: "Can be changed to test different versions of the firebolt-open-rpc",
+          url_Note: "Can be changed to test different versions of the firebolt-open-rpc",
           url: "https://rdkcentral.github.io/firebolt/requirements/latest/specifications/firebolt-open-rpc.json",
           name: "core",
         },


### PR DESCRIPTION
This PR updates the url inside of .mf.SAMPLE.config.json so that users have access to the most updated openRPC file.