### PR TITLE
SYSTEST-9542-Cannot read property 'toLowerCase' of undefined in mfos bug fix

### DIFF
--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -35,12 +35,6 @@ import { logger } from './logger.mjs';
 import { dereferenceMeta } from './fireboltOpenRpcDereferencing.mjs';
 import { isSdkEnabled } from './sdkManagement.mjs';
 
-//coverting module names to lowerCase 
-function toLowerCase(moduleName){
-  moduleName= moduleName.toLowerCase();
-  return moduleName;
-}
-
 // Build a method map for a single SDK (given by an object read from firebolt-xxx-sdk.json file)
 function buildMethodMap(sdkOpenrpc) {
   if ( ! sdkOpenrpc || ! isObject(sdkOpenrpc) ) { return {}; }
@@ -50,7 +44,7 @@ function buildMethodMap(sdkOpenrpc) {
   var result = sdkOpenrpc.methods.reduce(function(map, obj) {
     //coverting module names to lowerCase
     if(config.app.allowMixedCase){
-      obj.name = toLowerCase(obj.name);
+      obj.name = (obj.name).toLowerCase();
     }
     map[obj.name] = obj;
     return map;
@@ -71,7 +65,7 @@ function getMethod(methodName) {
   for ( let ii = 0; ii < config.dotConfig.supportedOpenRPCs.length; ii += 1 ) {
     const sdkName = config.dotConfig.supportedOpenRPCs[ii].name;
     if (config.app.allowMixedCase){
-      methodName = toLowerCase(methodName);
+      methodName = methodName.toLowerCase();
     }
     if ( methodMaps[sdkName] ) {
       if ( methodName in methodMaps[sdkName] ) { return methodMaps[sdkName][methodName]; }
@@ -344,8 +338,7 @@ readAllEnabledSdkJsonFiles()
 
 // --- Exports ---
 export const testExports={
-  rawMeta, meta, methodMaps, buildMethodMapsForAllEnabledSdks,
-  toLowerCase, buildMethodMap, downloadOpenRpcJsonFile
+  rawMeta, meta, methodMaps, buildMethodMapsForAllEnabledSdks, buildMethodMap, downloadOpenRpcJsonFile
 }
 export {
   getRawMeta, getMeta,

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -51,15 +51,15 @@ async function handleMessage(message, userId, ws) {
   logger.debug(`Received message for user ${userId} : ${message}`);
 
   const oMsg = JSON.parse(message);
-  if(config.app.allowMixedCase && oMsg.method){
+  if (oMsg.method && config.app.allowMixedCase) {
     oMsg.method = (oMsg.method).toLowerCase();
-  } else{
-    logger.error(`ERROR: Missing method field in message. Please make sure the message sent to MF is properly formatted`);
+  } else if (!oMsg.method) {
+    logger.error(`ERROR: Missing method field in message. Mock Firebolt expects incoming request to have a method field in the format <module.method>`);
     const oResponseMessage = {
       jsonrpc: '2.0',
       id: oMsg.id,
       error: {
-        message: 'ERROR: Missing method field in message. Please make sure the message sent to MF is properly formatted'
+        message: 'ERROR: Missing method field in message. Mock Firebolt expects incoming request to have a method field in the format <module.method>'
       }
     };
     const responseMessage = JSON.stringify(oResponseMessage);
@@ -67,6 +67,7 @@ async function handleMessage(message, userId, ws) {
     logger.debug(`Sent message for user ${userId}: ${responseMessage}`);
     return;
   }
+  
   // record the message if we are recording
   addCall(oMsg.method, oMsg.params, userId);
 

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -51,8 +51,21 @@ async function handleMessage(message, userId, ws) {
   logger.debug(`Received message for user ${userId} : ${message}`);
 
   const oMsg = JSON.parse(message);
-  if(config.app.allowMixedCase){
-    oMsg.method = fireboltOpenRpc.testExports.toLowerCase(oMsg.method);
+  if(config.app.allowMixedCase && oMsg.method){
+    oMsg.method = (oMsg.method).toLowerCase();
+  } else{
+    logger.error(`ERROR: Missing method field in message. Please make sure the message sent to MF is properly formatted`);
+    const oResponseMessage = {
+      jsonrpc: '2.0',
+      id: oMsg.id,
+      error: {
+        message: 'ERROR: Missing method field in message. Please make sure the message sent to MF is properly formatted'
+      }
+    };
+    const responseMessage = JSON.stringify(oResponseMessage);
+    ws.send(responseMessage);
+    logger.debug(`Sent message for user ${userId}: ${responseMessage}`);
+    return;
   }
   // record the message if we are recording
   addCall(oMsg.method, oMsg.params, userId);

--- a/server/src/routes/api/state.mjs
+++ b/server/src/routes/api/state.mjs
@@ -144,7 +144,7 @@ function setMethodResult(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
   if (config.app.allowMixedCase){
-    methodName = fireboltOpenRpc.testExports.toLowerCase(methodName);
+    methodName = methodName.toLowerCase();
   }
   if ( 'result' in req.body ) {
     const result = req.body.result;
@@ -186,7 +186,7 @@ function setMethodError(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
   if (config.app.allowMixedCase){
-    methodName = fireboltOpenRpc.testExports.toLowerCase(methodName);
+    methodName = methodName.toLowerCase();
   }
   if ( 'error' in req.body ) {
     const err = req.body.error;

--- a/server/test/suite/fireboltOpenRpc.test.mjs
+++ b/server/test/suite/fireboltOpenRpc.test.mjs
@@ -25,11 +25,6 @@ import { logger } from "../../src/logger.mjs";
 import * as fireboltOpenRpc from "../../src/fireboltOpenRpc.mjs";
 import { config } from "../../src/config.mjs";
 
-test(`fireboltOpenRpc.toLowerCase works properly`, () => {
-  const result = fireboltOpenRpc.testExports.toLowerCase("TEST");
-  expect(result).toBe("test");
-});
-
 test(`fireboltOpenRpc.getRawMeta works properly`, () => {
   const expectedResult = {
     core: {


### PR DESCRIPTION
Ticket - https://ccp.sys.comcast.net/browse/SYSTEST-9542
Changes made -
1. Added error handling for null/empty module/method in incoming MF requests
2. Got rid of the "toLowerCase()" function that just calls the native String "toLowerCase()