### PR TITLE
Modify allowMixedCase behavior and config name.

### DIFF
--- a/cli/examples/accessibility-closedCaptionsSettings.json
+++ b/cli/examples/accessibility-closedCaptionsSettings.json
@@ -1,6 +1,6 @@
 {
     "methods": {
-      "accessibility.closedcaptionssettings": {
+      "accessibility.closedCaptionsSettings": {
         "result": {"enabled":true,"styles":{"fontFamily":"testValue1","fontSize":1,"fontColor":"#ffffff","fontEdge":"none","fontEdgeColor":"#7F7F7F","fontOpacity":100,"backgroundColor":"#000000","backgroundOpacity":100,"textAlign":"center","textAlignVertical":"middle"}}
       }
     }

--- a/cli/examples/accessibility-closedCaptionsSettings2.json
+++ b/cli/examples/accessibility-closedCaptionsSettings2.json
@@ -1,6 +1,6 @@
 {
     "methods": {
-      "accessibility.closedcaptionssettings": {
+      "accessibility.closedCaptionsSettings": {
         "result": {"enabled":true,"styles":{"fontFamily":"testValue2","fontSize":1,"fontColor":"#ffffff","fontEdge":"none","fontEdgeColor":"#7F7F7F","fontOpacity":100,"backgroundColor":"#000000","backgroundOpacity":100,"textAlign":"center","textAlignVertical":"middle"}}
       }
     }

--- a/cli/examples/accessibility-onVoiceGuidanceSettingsChanged1.event.json
+++ b/cli/examples/accessibility-onVoiceGuidanceSettingsChanged1.event.json
@@ -1,5 +1,5 @@
 {
-  "method": "accessibility.onvoiceguidancesettingschanged",
+  "method": "accessibility.onVoiceGuidanceSettingsChanged",
   "result": {
       "enabled": false,
       "speed": 5

--- a/cli/examples/device-onNameChanged1.event.json
+++ b/cli/examples/device-onNameChanged1.event.json
@@ -1,4 +1,4 @@
 {
-  "method": "device.onnamechanged",
+  "method": "device.onNameChanged",
   "result": "NEW-DEVICE-NAME-1"
 }

--- a/cli/examples/lifecycle.yaml
+++ b/cli/examples/lifecycle.yaml
@@ -10,7 +10,7 @@ methods:
         }, 500)
 
         ctx.setTimeout(function() {
-        const result = {previous: 'inactive', state: 'foreground' }
+        const result = { previous: 'inactive', state: 'foreground' }
           const msg = 'Post trigger for lifecycle.ready sent foreground lifecycle event'
           ctx.sendEvent('lifecycle.onForeground', result, msg)
           }, 1000)

--- a/server/README.md
+++ b/server/README.md
@@ -542,3 +542,33 @@ curl --location --request GET 'http://localhost:3333/api/v1/status'
    status": "No WS connection found for user 12345"
 }
 ```
+
+# Server Configuration parameters (server/src/config.mjs):
+
+## app config object:
+```
+  app: {
+    caseInsensitiveModules: true,
+    socketPort: 9998,
+    httpPort: 3333,
+    wsSessionServerPort: 9999,
+    conduitSocketPort: 9997,
+    conduitKeySocketPort: 9996,         // Key forwarding from Conduit
+    developerToolPort: 9995,            // Port for Firebolt to connect to
+    developerToolName: 'Mock Firebolt', // Used when publishing with DNS-SD
+    defaultUserId: '12345',
+    magicDateTime: {
+      prefix: '{{',
+      suffix: '}}'
+    },
+    developerNotesTagName: 'developerNotes'
+  }
+```
+
+### caseInsensitiveModules:
+Firebolt calls are passed in the format <module>.<methodName>.
+Method names are always camelCase formated.
+However in early releases of the Firebolt SDK the module names were fully lowercase. (ex: closedcaptions). Starting with SDK v0.11.0 the module names were alteres to begin with an uppercase letter for each word instead (ex: ClosedCaptions).
+Setting the value for caseInsensitiveModules to true will internally convert the module names passed in method calls to a lowercase string for comparisons. Method names are left in camelCase format. This allows closedcaptions.setEnabled to be treated the same as ClosedCaption.setEnabled in the mock environment.
+
+This can be useful especially when certifying against different SDK releases.

--- a/server/README.md
+++ b/server/README.md
@@ -567,8 +567,8 @@ curl --location --request GET 'http://localhost:3333/api/v1/status'
 
 ### caseInsensitiveModules:
 Firebolt calls are passed in the format <module>.<methodName>.
-Method names are always camelCase formated.
-However in early releases of the Firebolt SDK the module names were fully lowercase. (ex: closedcaptions). Starting with SDK v0.11.0 the module names were alteres to begin with an uppercase letter for each word instead (ex: ClosedCaptions).
+Method names are always formatted with camelCase. 
+However, in early releases of the Firebolt SDK, the module names were fully lowercase. (ex: closedcaptions). Starting with SDK v0.11.0, the module names were altered to begin with an uppercase letter for each word instead (ex: ClosedCaptions).
 Setting the value for caseInsensitiveModules to true will internally convert the module names passed in method calls to a lowercase string for comparisons. Method names are left in camelCase format. This allows closedcaptions.setEnabled to be treated the same as ClosedCaption.setEnabled in the mock environment.
 
-This can be useful especially when certifying against different SDK releases.
+This can be useful, especially when certifying against different SDK releases.

--- a/server/src/changedConfigs.json
+++ b/server/src/changedConfigs.json
@@ -9,5 +9,11 @@
         "oldName": "supportedSDKs",
         "newName": "supportedOpenRPCs",
         "readme": "README.md"
+    },
+    {
+        "type": "changed",
+        "oldName": "allowMixedCase",
+        "newName": "caseInsensitiveModules",
+        "readme": "README.md"
     }
 ]

--- a/server/src/config.mjs
+++ b/server/src/config.mjs
@@ -37,7 +37,7 @@ const config = {
   multiUserConnections: "warn",
   
   app: {
-    allowMixedCase: true,
+    caseInsensitiveModules: true,
     socketPort: 9998,
     httpPort: 3333,
     wsSessionServerPort: 9999,

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -29,6 +29,8 @@ import { logger } from './logger.mjs';
 import * as fireboltOpenRpc from './fireboltOpenRpc.mjs';
 import { config } from './config.mjs';
 import { updateCallWithResponse } from './sessionManagement.mjs';
+import { createCaseAgnosticMethod } from './util.mjs';
+
 
 const { dotConfig: { eventConfig } } = config;
 
@@ -305,6 +307,9 @@ function emitResponse(finalResult, msg, userId, method) {
 
 // sendEvent to handle post API event calls, including pre- and post- event trigger processing
 function coreSendEvent(isBroadcast, ws, userId, method, result, msg, fSuccess, fErr, fFatalErr) {
+  if (config.app.allowMixedCase) {
+    method = createCaseAgnosticMethod(method);
+  }
   try {
     if (  ! isBroadcast && !isRegisteredEventListener(userId, method) ) {
       logger.info(`${method} event not registered`);

--- a/server/src/events.mjs
+++ b/server/src/events.mjs
@@ -307,7 +307,7 @@ function emitResponse(finalResult, msg, userId, method) {
 
 // sendEvent to handle post API event calls, including pre- and post- event trigger processing
 function coreSendEvent(isBroadcast, ws, userId, method, result, msg, fSuccess, fErr, fFatalErr) {
-  if (config.app.allowMixedCase) {
+  if (config.app.caseInsensitiveModules) {
     method = createCaseAgnosticMethod(method);
   }
   try {

--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -43,7 +43,7 @@ function buildMethodMap(sdkOpenrpc) {
 
   var result = sdkOpenrpc.methods.reduce(function(map, obj) {
     //coverting module names to lowerCase
-    if(config.app.allowMixedCase){
+    if(config.app.caseInsensitiveModules){
       obj.name = createCaseAgnosticMethod(obj.name);
     }
     map[obj.name] = obj;
@@ -64,7 +64,7 @@ function getMeta() {
 function getMethod(methodName) {
   for ( let ii = 0; ii < config.dotConfig.supportedOpenRPCs.length; ii += 1 ) {
     const sdkName = config.dotConfig.supportedOpenRPCs[ii].name;
-    if (config.app.allowMixedCase){
+    if (config.app.caseInsensitiveModules){
       methodName = createCaseAgnosticMethod(methodName);
     }
     if ( methodMaps[sdkName] ) {

--- a/server/src/fireboltOpenRpc.mjs
+++ b/server/src/fireboltOpenRpc.mjs
@@ -29,7 +29,7 @@ import * as https from 'https';
 import Ajv from 'ajv';
 const ajv = new Ajv();
 
-import { createTmpFile } from './util.mjs';
+import { createTmpFile,createCaseAgnosticMethod } from './util.mjs';
 import { config } from './config.mjs';
 import { logger } from './logger.mjs';
 import { dereferenceMeta } from './fireboltOpenRpcDereferencing.mjs';
@@ -44,7 +44,7 @@ function buildMethodMap(sdkOpenrpc) {
   var result = sdkOpenrpc.methods.reduce(function(map, obj) {
     //coverting module names to lowerCase
     if(config.app.allowMixedCase){
-      obj.name = (obj.name).toLowerCase();
+      obj.name = createCaseAgnosticMethod(obj.name);
     }
     map[obj.name] = obj;
     return map;
@@ -65,7 +65,7 @@ function getMethod(methodName) {
   for ( let ii = 0; ii < config.dotConfig.supportedOpenRPCs.length; ii += 1 ) {
     const sdkName = config.dotConfig.supportedOpenRPCs[ii].name;
     if (config.app.allowMixedCase){
-      methodName = methodName.toLowerCase();
+      methodName = createCaseAgnosticMethod(methodName);
     }
     if ( methodMaps[sdkName] ) {
       if ( methodName in methodMaps[sdkName] ) { return methodMaps[sdkName][methodName]; }

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -60,7 +60,7 @@ async function handleMessage(message, userId, ws) {
   logger.debug(`Received message for user ${userId} : ${message}`);
 
   const oMsg = JSON.parse(message);
-  if (oMsg.method && config.app.allowMixedCase) {
+  if (oMsg.method && config.app.caseInsensitiveModules) {
     oMsg.method = util.createCaseAgnosticMethod(oMsg.method);
   } else if (!oMsg.method) {
     logger.error(`ERROR: Missing method field in message. Mock Firebolt expects incoming request to have a method field in the format <module.method>`);

--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -61,7 +61,7 @@ async function handleMessage(message, userId, ws) {
 
   const oMsg = JSON.parse(message);
   if (oMsg.method && config.app.allowMixedCase) {
-    oMsg.method = (oMsg.method).toLowerCase();
+    oMsg.method = util.createCaseAgnosticMethod(oMsg.method);
   } else if (!oMsg.method) {
     logger.error(`ERROR: Missing method field in message. Mock Firebolt expects incoming request to have a method field in the format <module.method>`);
     const oResponseMessage = {

--- a/server/src/routes/api/state.mjs
+++ b/server/src/routes/api/state.mjs
@@ -21,7 +21,7 @@
 'use strict';
 
 import { logger } from '../../logger.mjs';
-import { getUserIdFromReq } from '../../util.mjs';
+import { getUserIdFromReq,createCaseAgnosticMethod } from '../../util.mjs';
 import * as fireboltOpenRpc from '../../fireboltOpenRpc.mjs';
 import * as commonErrors from '../../commonErrors.mjs';
 import * as stateManagement from '../../stateManagement.mjs';
@@ -144,7 +144,7 @@ function setMethodResult(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
   if (config.app.allowMixedCase){
-    methodName = methodName.toLowerCase();
+    methodName = createCaseAgnosticMethod(methodName);
   }
   if ( 'result' in req.body ) {
     const result = req.body.result;
@@ -186,7 +186,7 @@ function setMethodError(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
   if (config.app.allowMixedCase){
-    methodName = methodName.toLowerCase();
+    methodName = createCaseAgnosticMethod(methodName);
   }
   if ( 'error' in req.body ) {
     const err = req.body.error;

--- a/server/src/routes/api/state.mjs
+++ b/server/src/routes/api/state.mjs
@@ -143,7 +143,7 @@ function setMode(req, res) {
 function setMethodResult(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
-  if (config.app.allowMixedCase){
+  if (config.app.caseInsensitiveModules){
     methodName = createCaseAgnosticMethod(methodName);
   }
   if ( 'result' in req.body ) {
@@ -185,7 +185,7 @@ function setMethodResult(req, res) {
 function setMethodError(req, res) {
   const userId = getUserIdFromReq(req);
   let methodName = req.params.methodName;
-  if (config.app.allowMixedCase){
+  if (config.app.caseInsensitiveModules){
     methodName = createCaseAgnosticMethod(methodName);
   }
   if ( 'error' in req.body ) {

--- a/server/src/util.mjs
+++ b/server/src/util.mjs
@@ -160,10 +160,12 @@ function replaceKeyInObject(obj, oldKey, newKey) {
 * @Return: Return string in the format (moduleName.methodName) with only the moduleName having been converted to lowercase
 */
 function createCaseAgnosticMethod(method){
-  let splitArray = method.split('.');
-  let moduleName = splitArray[0].toLowerCase();
-  let methodName = splitArray[1];
-  method = moduleName.concat(".", methodName);
+  if (method.includes(".")){
+    let splitArray = method.split('.');
+    let moduleName = splitArray[0].toLowerCase();
+    let methodName = splitArray[1];
+    method = moduleName.concat(".", methodName);
+  }
   return method;
 }
 

--- a/server/src/util.mjs
+++ b/server/src/util.mjs
@@ -153,6 +153,13 @@ function replaceKeyInObject(obj, oldKey, newKey) {
   return obj;
 }
 
+function createCaseAgnosticMethod(methodName){
+  let splitMethodArray = methodName.split('.');
+  let moduleName = splitMethodArray[0].toLowerCase();
+  methodName = splitMethodArray[1];
+  let fullMethodName = moduleName.concat(".", methodName);
+  return fullMethodName;
+}
 // --- Exports ---
 
-export { delay, randomIntFromInterval, getUserIdFromReq, createTmpFile, mergeArrayOfStrings, createAbsoluteFilePath, getCreationDate, getModificationDate, searchObjectForKey, replaceKeyInObject };
+export { delay, randomIntFromInterval, getUserIdFromReq, createTmpFile, mergeArrayOfStrings, createAbsoluteFilePath, getCreationDate, getModificationDate, searchObjectForKey, replaceKeyInObject, createCaseAgnosticMethod };

--- a/server/src/util.mjs
+++ b/server/src/util.mjs
@@ -153,6 +153,12 @@ function replaceKeyInObject(obj, oldKey, newKey) {
   return obj;
 }
 
+/* 
+* @function:createCaseAgnosticMethod
+* @Description: Convert a provided full method (moduleName.methodName) to be case insensitive for the module name
+* @param {String} methodName - String containing module and method names delimited by '.'
+* @Return: Return string in the format (moduleName.methodName) with only the moduleName having been converted to lowercase
+*/
 function createCaseAgnosticMethod(methodName){
   let splitMethodArray = methodName.split('.');
   let moduleName = splitMethodArray[0].toLowerCase();
@@ -160,6 +166,7 @@ function createCaseAgnosticMethod(methodName){
   let fullMethodName = moduleName.concat(".", methodName);
   return fullMethodName;
 }
+
 // --- Exports ---
 
 export { delay, randomIntFromInterval, getUserIdFromReq, createTmpFile, mergeArrayOfStrings, createAbsoluteFilePath, getCreationDate, getModificationDate, searchObjectForKey, replaceKeyInObject, createCaseAgnosticMethod };

--- a/server/src/util.mjs
+++ b/server/src/util.mjs
@@ -156,15 +156,15 @@ function replaceKeyInObject(obj, oldKey, newKey) {
 /* 
 * @function:createCaseAgnosticMethod
 * @Description: Convert a provided full method (moduleName.methodName) to be case insensitive for the module name
-* @param {String} methodName - String containing module and method names delimited by '.'
+* @param {String} method - String containing module and method names delimited by '.'
 * @Return: Return string in the format (moduleName.methodName) with only the moduleName having been converted to lowercase
 */
-function createCaseAgnosticMethod(methodName){
-  let splitMethodArray = methodName.split('.');
-  let moduleName = splitMethodArray[0].toLowerCase();
-  methodName = splitMethodArray[1];
-  let fullMethodName = moduleName.concat(".", methodName);
-  return fullMethodName;
+function createCaseAgnosticMethod(method){
+  let splitArray = method.split('.');
+  let moduleName = splitArray[0].toLowerCase();
+  let methodName = splitArray[1];
+  method = moduleName.concat(".", methodName);
+  return method;
 }
 
 // --- Exports ---

--- a/server/test/suite/config.test.mjs
+++ b/server/test/suite/config.test.mjs
@@ -27,7 +27,7 @@ test(`config works properly`, () => {
     validate: ["method", "params", "response", "events"],
     multiUserConnections: "warn",
     app: {
-      allowMixedCase: true,
+      caseInsensitiveModules: true,
       socketPort: 9998,
       httpPort: 3333,
       wsSessionServerPort: 9999,

--- a/server/test/suite/events.test.mjs
+++ b/server/test/suite/events.test.mjs
@@ -209,7 +209,7 @@ test(`events.sendUnRegistrationAck works properly`, () => {
 
 
 test(`events.sendEvent works properly`, () => {
-  const methodName = "test",
+  const methodName = "test.eventTest",
     result = {
       name: "OpenRPC Schema",
       schema: {

--- a/server/test/suite/fireboltOpenRpc.test.mjs
+++ b/server/test/suite/fireboltOpenRpc.test.mjs
@@ -230,13 +230,13 @@ test(`fireboltOpenRpc.getMethod works properly`, () => {
   ];
   const configArray = [false, false, true];
   expectedInput.forEach((methodName, index) => {
-    config.app.allowMixedCase = configArray[index];
+    config.app.caseInsensitiveModules = configArray[index];
     const result = fireboltOpenRpc.getMethod(methodName);
     if (configArray[index]) {
       expect(result).toBeUndefined();
     } else expect(result).toEqual(expectedOutput[index]);
   });
-  config.app.allowMixedCase = false;
+  config.app.caseInsensitiveModules = false;
 });
 
 test(`fireboltOpenRpc.isMethodKnown works properly`, () => {
@@ -753,7 +753,7 @@ test(`fireboltOpenRpc.buildMethodMapsForAllEnabledSdks works properly`, () => {
 test(`fireboltOpenRpc.buildMethodMap works properly`, () => {
   const inputs = [{}, { test: "test" }];
   const outputs = ["undefined", "undefined", "object"];
-  config.app.allowMixedCase = true;
+  config.app.caseInsensitiveModules = true;
   outputs.forEach((output, index) => {
     let result;
     if (index === 2) {
@@ -763,7 +763,7 @@ test(`fireboltOpenRpc.buildMethodMap works properly`, () => {
     }
     expect(typeof result).toBe(output);
   });
-  config.app.allowMixedCase = false;
+  config.app.caseInsensitiveModules = false;
 });
 
 test(`fireboltOpenRpc.downloadOpenRpcJsonFile works properly`, () => {


### PR DESCRIPTION
Changes included:

1. allowMixedCase config was renamed to caseInsensitiveModules.
2. README entry was written for caseInsensitiveModules behavior.
3. caseInsensitiveModules was modified to only allow the module name to be case insensitive instead of the full method name to better represent the SDK itself.
4. Examples were modified to reflect the new behavior.
5. Additional check was added for events to address https://github.com/rdkcentral/mock-firebolt/issues/145. Which makes https://github.com/rdkcentral/mock-firebolt/pull/146 no longer needed.
6. Mapping was added in server/src/changedConfigs.json to allow backwards compatibility.