### PR TITLE
Remove stale ws connections from user2ws map when connection is closed

### DIFF
--- a/functional/package.json
+++ b/functional/package.json
@@ -6,7 +6,7 @@
     "test": "NODE_ENV=test npx jest --config=jest.config.js --silent -i",
     "test:openRpcCall": "NODE_ENV=test npx jest --config=jest.config.js --forceExit -- ./tests/openRpcCall.test.mjs",
     "test:healthCheck": "NODE_ENV=test npx jest --config=jest.config.js --forceExit -- ./tests/health-check.test.mjs",
-    "test:scope": "NODE_ENV=test npx jest --config=jest.config.js  --forceExit -- ./tests/scope.test.mjs"
+    "test:scope": "NODE_ENV=test npx jest --config=jest.config.js --forceExit -- ./tests/scope.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/functional/tests/openRpcCall.test.mjs
+++ b/functional/tests/openRpcCall.test.mjs
@@ -46,35 +46,41 @@ test(`MF Startup/Health Check`, async () => {
 
 // JsonRpc for CORE SDK
 test(`Validate OPENRPC Response for CORE SDK`, async () => {
-  const response = await utilities.fireboltCommand(
+  const commander = new utilities.FireboltCommander();
+  const response = await commander.sendCommand(
     JSON.stringify({
       method: "Accessibility.closedCaptionsSettings",
       params: {},
       id: 0,
-    })
-  );
+  }));
+  commander.closeConnection();
+
   expect(response.includes('"enabled":true')).toEqual(true);
 });
 
 test(`Validate OPENRPC Response for manage SDK`, async () => {
-  const response = await utilities.fireboltCommand(
+  const commander = new utilities.FireboltCommander();
+  const response = await commander.sendCommand(
     JSON.stringify({
       method: "UserGrants.device",
       params: {},
       id: 0,
-    })
-  );
+  }));
+  commander.closeConnection();
+
   expect(response.includes(`"state":"granted"`)).toEqual(true);
 });
 
 test(`Validate firebolt response for Discovery SDK`, async () => {
-  const response = await utilities.fireboltCommand(
+  const commander = new utilities.FireboltCommander();
+  const response = await commander.sendCommand(
     JSON.stringify({
       method: "content.providers",
       params: {},
       id: 0,
-    })
-  );
+  }));
+  commander.closeConnection();
+
   expect(response.includes(`"id":"NetflixApp"`)).toEqual(true);
 });
 
@@ -166,41 +172,45 @@ test(`Validate start and stop session`, async () => {
 
 // Send event for default user
 test(`Validate send event for default user`, async () => {
-  await utilities.fireboltCommand(
+  const commander = new utilities.FireboltCommander();
+  await commander.sendCommand(
     JSON.stringify({
       method: "Accessibility.onVoiceGuidanceSettingsChanged",
-      params: { listen: true },
+      params: { listen: true},
       id: 4,
-    })
-  );
+  }));
+  
   const result = await utilities.callMfCli(
     `cd ../cli/src/ && node cli.mjs --event ../examples/accessibility-onVoiceGuidanceSettingsChanged1.event.json && cd ../../functional`,
     true
   );
   expect(result.includes(`{ status: 'SUCCESS' }`)).toBe(true);
+  commander.closeConnection();
 });
 
 // Broadcast event for a particular user
 test(`Validate broadcast event for a user in a group and Validate that other user in that group getting that`, async () => {
-  await utilities.fireboltCommand(
+  const commander = new utilities.FireboltCommander(9998, "567~B");
+  await commander.sendCommand(
     JSON.stringify({
-      method: "Device.onNameChanged",
-      params: { listen: true },
-      id: 11,
-    }),
-    9998,
-    "567~B"
-  );
+    method: "Device.onNameChanged",
+    params: { listen: true },
+    id: 11,
+  }));
+
   const result = await utilities.callMfCli(
     `cd ../cli/src/ && node cli.mjs --broadcastEvent ../examples/device-onNameChanged1.event.json --user 567~B && cd ../../functional`,
     true
   );
+
   expect(result.includes(`{ status: 'SUCCESS' }`)).toBe(true);
   const resultTwo = await utilities.callMfCli(
     `cd ../cli/src/ && node cli.mjs --broadcastEvent ../examples/device-onNameChanged1.event.json --user 978~B && cd ../../functional`,
     true
   );
   expect(resultTwo.includes(`{ status: 'SUCCESS' }`)).toBe(true);
+
+  commander.closeConnection();
 });
 
 // Send event without any active listener

--- a/functional/tests/scope.test.mjs
+++ b/functional/tests/scope.test.mjs
@@ -23,6 +23,8 @@ import * as utilities from "./utilities.mjs";
 
 jest.setTimeout(20000);
 
+let commander;
+
 beforeAll(async () => {
     const response = await utilities.mfState(
         true,
@@ -30,6 +32,8 @@ beforeAll(async () => {
     );
     console.log(response)
     expect(response).toBe("MF started successfully");
+    
+    commander = new utilities.FireboltCommander(9998, "123~A");
 });
 
 afterAll(async () => {
@@ -41,18 +45,18 @@ afterAll(async () => {
 
 // Updating method for a particular user
 test(`Validate group scope updates`, async () => {
-
-    const userId = "123~A"
     const group = "~A"
     const fbCommand = "accessibility.closedCaptionsSettings"
 
     //Validate the OpenRPC response
-    let result = await utilities.fireboltCommand(
+    let result = await commander.sendCommand(
         JSON.stringify({
             method: fbCommand,
             params: {},
             id: 0,
-          }), null, userId)
+        })
+    );    
+    
     console.log(JSON.stringify(result))
     expect(result.includes('\"fontFamily\":\"Monospace sans-serif\"')).toBe(true)
 
@@ -63,12 +67,14 @@ test(`Validate group scope updates`, async () => {
     );
     
     //Validate the override took effect
-    result = await utilities.fireboltCommand(
+    result = await commander.sendCommand(
         JSON.stringify({
             method: fbCommand,
             params: {},
             id: 0,
-          }), null, userId)
+          })
+    );
+   
     console.log(JSON.stringify(result))
     expect(result.includes('\"fontFamily\":\"testValue1\"')).toBe(true)
 
@@ -79,12 +85,16 @@ test(`Validate group scope updates`, async () => {
     );
 
     //Validate the second override took effect
-    result = await utilities.fireboltCommand(
+    result = await commander.sendCommand(
         JSON.stringify({
             method: fbCommand,
             params: {},
             id: 0,
-          }), null, userId)
+        })
+    );
+
     console.log(JSON.stringify(result))
     expect(result.includes('\"fontFamily\":\"testValue2\"')).toBe(true)
+
+    commander.closeConnection();
  });

--- a/server/src/userManagement.mjs
+++ b/server/src/userManagement.mjs
@@ -222,6 +222,12 @@ function addUser(userId) {
     ws.on('pong', async hb => {
       heartbeat(ws)
     });
+
+    // Remove ws connection of user
+    ws.on('close', function close() {
+      deleteWsOfUser(ws, userId);
+    });
+
     // If multiUserConnections configuration is set as deny and there is a ws object associated with userId, deny and log second ws connection and drop the attempt
     if (/deny/i.test(config.multiUserConnections) == true && getWsForUser(userId) !== undefined) {
       logger.info(`Denying second websocket connection of user ${userId}`)

--- a/server/src/userManagement.mjs
+++ b/server/src/userManagement.mjs
@@ -225,7 +225,7 @@ function addUser(userId) {
 
     // Remove ws connection of user
     ws.on('close', function close() {
-      deleteWsOfUser(ws, userId);
+      closeConnection(userId, ws);
     });
 
     // If multiUserConnections configuration is set as deny and there is a ws object associated with userId, deny and log second ws connection and drop the attempt


### PR DESCRIPTION
### Enhancements to WebSocket Connection Management and Unit Tests

**Summary:**

This pull request introduces improvements to the existing WebSocket (ws) connection management and functional unit tests. Key changes include:

**WebSocket Connection Cleanup:** I've extended the current functionality that monitors and terminates stale ws connections. Now, when a ws connection is closed—whether due to inactivity or explicitly by a user—it's also removed from the _user2ws_ map. This map maintains a record of active ws connections for each user, ensuring the list remains accurate and up-to-date.

**Unit Test Refactoring:** A failing functional unit test caused by the above changes highlighted an issue where WebSocket connections were closed immediately after message receipt, hindering subsequent commands within the same test scenario. To address this, I refactored the existing function-based approach into a more robust class. This class establishes a WebSocket connection and provides methods for sending commands and closing the ws connection. This enhancement simplifies test scenarios involving multiple commands and avoids the overhead of repeatedly opening and closing connections.