### PR TITLE
fix: Return only error message when invalid params are sent to mf

### DIFF
--- a/server/src/messageHandler.mjs
+++ b/server/src/messageHandler.mjs
@@ -168,7 +168,8 @@ async function handleMessage(message, userId, ws) {
     // No delay
     ws.send(responseMessage);
     logger.info(`Sent "invalid params" message: ${responseMessage}`);
-    updateCallWithResponse(oMsg.method, oResponseMessage.error, "error", userId)
+    updateCallWithResponse(oMsg.method, oResponseMessage.error, "error", userId);
+    return;
   }
 
   // Fire pre trigger if there is one for this method  


### PR DESCRIPTION
Currently Mock Firebolt sends both an error message and a default response when a message with invalid params is sent to the server and validated. MF should only send back error message and should not send a default response as well.