### PR TITLE
Indicate bidirectional payload with an id from different set

### DIFF
--- a/server/src/routes/api/bidirectional.mjs
+++ b/server/src/routes/api/bidirectional.mjs
@@ -23,7 +23,7 @@
 import { getUserIdFromReq } from '../../util.mjs';
 import * as userManagement from '../../userManagement.mjs'
 
-let id = 1
+let id = 1001
 
 function getIdAndIncrement() {
     id++;


### PR DESCRIPTION
Because bidirectional payload does not references to message-id being used by the other parts of mock-firebolt, I have set starting ID value to be from a different range, until proper fix implemented.
Rationale: when inspecting logs, it looked like the same IDs were reused.